### PR TITLE
expose classes in index.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,21 @@
   "name": "@imranq2/fhirpatientsummary",
   "version": "x.x.x",
   "description": "A template for creating npm packages using TypeScript and VSCode",
-  "main": "./lib/index.js",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "exports": {
+    "import": "./lib/esm/index.js",
+    "require": "./lib/cjs/index.js"
+  },
+  "types": "./lib/cjs/index.d.ts",
   "files": [
     "lib/**/*"
   ],
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
+    "build:cjs": "tsc --project tsconfig.cjs.json",
+    "build:esm": "tsc --project tsconfig.esm.json",
+    "build": "npm run build:cjs && npm run build:esm",
     "clean": "rm -rf ./lib/",
     "cm": "cz",
     "lint": "eslint ./src/ --ext .ts --fix",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export const myPackage = (taco = ''): string => `${taco} from my package`;
+export { ComprehensiveIPSCompositionBuilder } from "./generators/fhir_summary_generator";
+export { NarrativeGenerator } from "./generators/narrative_generator";

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./lib/cjs"
+  },
+  "exclude": [
+    "test/**/*.spec.ts"
+  ]
+}
+

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "outDir": "./lib/esm"
+  },
+  "exclude": [
+    "test/**/*.spec.ts"
+  ]
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,7 +48,7 @@
     // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",
     // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
     // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
This PR exposes two additional classes in the public API by adding exports to the index file.

Adds export for ComprehensiveIPSCompositionBuilder from fhir_summary_generator.
Adds export for NarrativeGenerator from narrative_generator.