### PR TITLE
fix path to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "@imranq2/fhirpatientsummary",
   "version": "x.x.x",
   "description": "A template for creating npm packages using TypeScript and VSCode",
-  "main": "./lib/cjs/index.js",
-  "module": "./lib/esm/index.js",
+  "main": "./lib/cjs/src/index.js",
+  "module": "./lib/esm/src/index.js",
   "exports": {
-    "import": "./lib/esm/index.js",
-    "require": "./lib/cjs/index.js"
+    "import": "./lib/esm/src/index.js",
+    "require": "./lib/cjs/src/index.js"
   },
-  "types": "./lib/cjs/index.d.ts",
+  "types": "./lib/cjs/src/index.d.ts",
   "files": [
     "lib/**/*"
   ],


### PR DESCRIPTION
This PR updates the package entry points to new build output paths by including the src directory segment.

Updated main, module, exports, and types fields to point at lib/{cjs,esm}/src/index.*
Left files globs unchanged, still publishing everything under lib/**/*
