### PR TITLE
feat!: remove IPS Composition priority tier (DCON-4025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,25 +72,14 @@ When generating patient summaries from FHIR Bundles, the library can use pre-com
 
 The `readBundleAsync` method supports a `useSummaryCompositions` parameter. When enabled, the library follows this priority order when processing each IPS section:
 
-1. **IPS-Specific Composition** (highest priority): Compositions with IPS-specific type codes (e.g., `ips_patient_summary_document`, `ips_vital_summary_document`)
-2. **Summary Composition** (medium priority): Compositions with summary type codes (e.g., `allergy_summary_document`, `condition_summary_document`, `medication_summary_document`)
-3. **Raw Resources** (fallback): Individual FHIR resources when no composition is available
+1. **Summary Composition** (highest priority): Compositions with summary type codes (e.g., `allergy_summary_document`, `condition_summary_document`, `medication_summary_document`)
+2. **Raw Resources** (fallback): Individual FHIR resources when no composition is available
 
 This priority order ensures that the most refined and curated data is used when available, while still supporting raw resource processing as a fallback.
 
 ### Environment Variables for enabling Composition Summary
 
 The following environment variables can be used to configure the behavior of the patient summary generator:
-
-#### SUMMARY_IPS_COMPOSITION_SECTIONS
-
-Controls which IPS sections should include IPS-specific composition.
-
-- **Default**: Disabled
-- **Format**: Comma-separated list of section names
-- **Example**: `SUMMARY_IPS_COMPOSITION_SECTIONS=Patient,VitalSignsSection`
-
-When set to `all`, all supported sections will use IPS composition. To enable only specific sections, provide a comma-separated list of [section names](src/structures/ips_sections.ts).
 
 #### SUMMARY_COMPOSITION_SECTIONS
 

--- a/src/generators/fhir_summary_generator.ts
+++ b/src/generators/fhir_summary_generator.ts
@@ -211,13 +211,6 @@ export class ComprehensiveIPSCompositionBuilder {
 
         // find resources for each section in IPSSections and add the section
         for (const sectionType of Object.values(IPSSections)) {
-            const summaryIPSCompositionFilter = useSummaryCompositions ? IPSSectionResourceHelper.getSummaryIPSCompositionFilterForSection(sectionType) : undefined;
-            const sectionIPSSummary = summaryIPSCompositionFilter ? resources.filter(resource => summaryIPSCompositionFilter(resource)) : [];
-            if (sectionIPSSummary.length > 0) {
-                consoleLogger.info(`Using IPS summary composition for section: ${sectionType}`);
-                await this.makeSectionFromSummaryAsync(sectionType, sectionIPSSummary as TComposition[], resources as TDomainResource[], timezone, includeSummaryCompositionOnly);
-                continue;
-            }
             const summaryCompositionFilter = useSummaryCompositions ? IPSSectionResourceHelper.getSummaryCompositionFilterForSection(sectionType) : undefined;
             const sectionSummary = summaryCompositionFilter ? resources.filter(resource => summaryCompositionFilter(resource)) : [];
             if (sectionSummary.length > 0) {
@@ -371,11 +364,9 @@ export class ComprehensiveIPSCompositionBuilder {
         const remainingResources = new Set<string>()
 
         for (const sectionType of Object.values(IPSSections)) {
-            const summaryIPSCompositionFilter = IPSSectionResourceHelper.getSummaryIPSCompositionFilterForSection(sectionType);
-            const sectionIPSSummary = summaryIPSCompositionFilter ? resources.filter(resource => summaryIPSCompositionFilter(resource)) : [];
             const summaryCompositionFilter = IPSSectionResourceHelper.getSummaryCompositionFilterForSection(sectionType);
             const sectionSummary = summaryCompositionFilter ? resources.filter(resource => summaryCompositionFilter(resource)) : [];
-            if (sectionSummary.length === 0 && sectionIPSSummary.length === 0) {
+            if (sectionSummary.length === 0) {
                 const resourcesForSection = IPSSectionResourceHelper.getResourceTypesForSection(sectionType);
                 resourcesForSection.forEach((resourceType) => {
                     if (!remainingResources.has(resourceType) && !resources.some(r => r.resourceType === resourceType)) {

--- a/src/structures/ips_section_constants.ts
+++ b/src/structures/ips_section_constants.ts
@@ -9,14 +9,12 @@ const VITAL_SIGNS_SUMMARY_COMPONENT_MAP = {
 const RESULT_SUMMARY_OBSERVATION_CATEGORIES = ["laboratory","Lab","LAB"]
 const RESULT_SUMMARY_OBSERVATION_DATE_FILTER = 2 * 365 * 24 * 60 * 60 * 1000; // 2 years in milliseconds
 
-const IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM = "https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/";
 const IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM = "https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/type";
 const IPS_SUMMARY_COMPOSITION_VIEW_TYPE_SYSTEM = "https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/view-type"
-export { 
+export {
     VITAL_SIGNS_SUMMARY_COMPONENT_MAP,
     IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM,
     IPS_SUMMARY_COMPOSITION_VIEW_TYPE_SYSTEM,
-    IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM,
     RESULT_SUMMARY_OBSERVATION_CATEGORIES,
     RESULT_SUMMARY_OBSERVATION_DATE_FILTER
 };

--- a/src/structures/ips_section_resource_map.ts
+++ b/src/structures/ips_section_resource_map.ts
@@ -1,4 +1,4 @@
-import { IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM, IPS_SUMMARY_COMPOSITION_VIEW_TYPE_SYSTEM, IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM, RESULT_SUMMARY_OBSERVATION_CATEGORIES } from "./ips_section_constants";
+import { IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM, IPS_SUMMARY_COMPOSITION_VIEW_TYPE_SYSTEM, RESULT_SUMMARY_OBSERVATION_CATEGORIES } from "./ips_section_constants";
 import { PREGNANCY_LOINC_CODES, SOCIAL_HISTORY_LOINC_CODES, PREGNANCY_SNOMED_CODES, FUNCTIONAL_STATUS_ASSESSMENT_LOINC_CODES, FUNCTIONAL_STATUS_SNOMED_CODES } from "./ips_section_loinc_codes";
 import { IPSSections } from "./ips_sections";
 import { TCodeableConcept } from "../types/partials/CodeableConcept";
@@ -91,17 +91,6 @@ export const IPSSectionSummaryCompositionFilter: Partial<Record<IPSSections, IPS
     [IPSSections.PROCEDURES]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "procedure_group_code", IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM)),
 }
 
-export const IPSSectionSummaryIPSCompositionFilter: Partial<Record<IPSSections, IPSSectionResourceFilter>> = {
-    [IPSSections.PATIENT]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "ips_patient_summary_document", IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM)),
-    [IPSSections.VITAL_SIGNS]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "ips_vital_summary_document", IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM)),
-    [IPSSections.ADVANCE_DIRECTIVES]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "ips_advanced_directives_summary_document", IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM)),
-    [IPSSections.SOCIAL_HISTORY]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "ips_social_history_summary_document", IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM)),
-    [IPSSections.FUNCTIONAL_STATUS]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, ["ips_functional_status_condition_summary_document", "ips_functional_status_clinical_impression_summary_document"], IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM)),
-    [IPSSections.MEDICAL_DEVICES]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "ips_medical_device_summary_document", IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM)),
-    [IPSSections.PREGNANCY_HISTORY]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "ips_pregnancy_history_summary_document", IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM)),
-    [IPSSections.DIAGNOSTIC_REPORTS]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, ["ips_diagnosticreportlab_summary_document", "ips_lab_summary_document"], IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM)),
-}
-
 // Helper class to get resource types for a section
 export class IPSSectionResourceHelper {
     static getResourceFilterForSection(section: IPSSections): IPSSectionResourceFilter {
@@ -129,19 +118,6 @@ export class IPSSectionResourceHelper {
             : false;
 
         return sectionCompositionEnabled ? IPSSectionSummaryCompositionFilter[section] : undefined;
-    }
-
-    static getSummaryIPSCompositionFilterForSection(section: IPSSections): IPSSectionResourceFilter | undefined {
-        const sectionIPSCompositionEnabled = process.env
-            .SUMMARY_IPS_COMPOSITION_SECTIONS
-            ? process.env.SUMMARY_IPS_COMPOSITION_SECTIONS.split(',').some(
-                s =>
-                    s.trim().toLowerCase() === section.toString().toLowerCase() ||
-                    s.trim().toLowerCase() === 'all'
-            )
-            : false;
-
-        return sectionIPSCompositionEnabled ? IPSSectionSummaryIPSCompositionFilter[section] : undefined;
     }
 }
 

--- a/tests/fhir-summary-bundle/fhir-summary-bundle.test.ts
+++ b/tests/fhir-summary-bundle/fhir-summary-bundle.test.ts
@@ -82,7 +82,6 @@ describe('FHIR Patient Summary Generation', () => {
     });
 
     it('should generate the correct summary for bundle having summary composition', async () => {
-        process.env.SUMMARY_IPS_COMPOSITION_SECTIONS = 'all';
         process.env.SUMMARY_COMPOSITION_SECTIONS = 'all';
         // Read the test bundle JSON
         const inputBundle = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/test-summary-bundle.json'), 'utf-8'));
@@ -121,12 +120,10 @@ describe('FHIR Patient Summary Generation', () => {
         expect(bundle.entry).toBeDefined();
         await compare_bundles(path.join(__dirname, 'fixtures/narratives/summary'), bundle, expectedBundle);
 
-        process.env.SUMMARY_IPS_COMPOSITION_SECTIONS = '';
         process.env.SUMMARY_COMPOSITION_SECTIONS = '';
     });
 
     it('should generate the correct summary for bundle having summary composition with completed medications', async () => {
-        process.env.SUMMARY_IPS_COMPOSITION_SECTIONS = 'all';
         process.env.SUMMARY_COMPOSITION_SECTIONS = 'all';
 
         // Read the test bundle JSON
@@ -166,12 +163,10 @@ describe('FHIR Patient Summary Generation', () => {
         expect(bundle.entry).toBeDefined();
         await compare_bundles(path.join(__dirname, 'fixtures/narratives/summary-no-medication'), bundle, expectedBundle);
 
-        process.env.SUMMARY_IPS_COMPOSITION_SECTIONS = '';
         process.env.SUMMARY_COMPOSITION_SECTIONS = '';
     });
 
     it('should get the correct required resources list from bundle', async () => {
-        process.env.SUMMARY_IPS_COMPOSITION_SECTIONS = 'all';
         process.env.SUMMARY_COMPOSITION_SECTIONS = 'all';
         // Read the test bundle JSON
         const inputBundle = JSON.parse(fs.readFileSync(path.join(__dirname, 'fixtures/required-resource-bundle.json'), 'utf-8'));
@@ -185,10 +180,9 @@ describe('FHIR Patient Summary Generation', () => {
         const builder = new ComprehensiveIPSCompositionBuilder().setPatient(mockPatient);
         const requiredResources = builder.getRemainingResourcesFromCompositionBundle(inputBundle);
 
-        const expectedResources = ['Condition', 'AllergyIntolerance', 'MedicationRequest', 'MedicationStatement', 'Medication', 'Immunization', 'Organization', 'DiagnosticReport', 'Observation', 'Procedure', 'Consent', 'CarePlan'];
+        const expectedResources = ['Condition', 'ClinicalImpression', 'AllergyIntolerance', 'MedicationRequest', 'MedicationStatement', 'Medication', 'Immunization', 'Organization', 'DiagnosticReport', 'Observation', 'Procedure', 'DeviceUseStatement', 'Device', 'Consent', 'CarePlan'];
 
         expect(requiredResources.sort()).toEqual(expectedResources.sort());
-        process.env.SUMMARY_IPS_COMPOSITION_SECTIONS = '';
         process.env.SUMMARY_COMPOSITION_SECTIONS = '';
     });
 });

--- a/tests/full_record/full_record.test.ts
+++ b/tests/full_record/full_record.test.ts
@@ -31,7 +31,6 @@ describe('Full Record Bundle Generation', () => {
     });
 
     it('should generate the correct summary for the concatenated full record bundle', async () => {
-        process.env.SUMMARY_IPS_COMPOSITION_SECTIONS = 'all';
         process.env.SUMMARY_COMPOSITION_SECTIONS = 'all';
 
         // Path to the sandbox fixtures
@@ -76,7 +75,6 @@ describe('Full Record Bundle Generation', () => {
         // If you have an expected bundle, replace inputBundle below
         await compare_bundles(path.join(__dirname, 'fixtures/expected/narratives'), bundle, inputBundle);
 
-        process.env.SUMMARY_IPS_COMPOSITION_SECTIONS = '';
         process.env.SUMMARY_COMPOSITION_SECTIONS = '';
     });
 });


### PR DESCRIPTION
## Summary

- Removes the priority-1 **IPS Composition** tier (`SUMMARY_IPS_COMPOSITION_SECTIONS`, `IPSSectionSummaryIPSCompositionFilter`, `IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM`, the `ips_*_summary_document` matchers) from `readBundleAsync` and `getRemainingResourcesFromCompositionBundle`.
- Keeps the **IL Composition** tier (`SUMMARY_COMPOSITION_SECTIONS`, `IPSSectionSummaryCompositionFilter`) and the `ComprehensiveIPSCompositionBuilder` export — both unchanged.
- Bundles containing `ips_*_summary_document` Compositions now fall through to the IL tier or the raw-resource fallback, matching the simplified two-tier priority documented in the README.

Spec: `docs/superpowers/specs/2026-06-04-remove-ips-composition-tier-design.md`
Reference: [IPS Section Composition (Confluence)](https://icanbwell.atlassian.net/wiki/spaces/ENTFS/pages/5878480956/IPS+Section+Composition)

## ⚠️ Breaking Change

`SUMMARY_IPS_COMPOSITION_SECTIONS` is now a no-op. Sections previously rendered from `ips_*_summary_document` Compositions will render from IL Compositions or raw resources.

## Files Changed

- `src/structures/ips_section_constants.ts` — drop `IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM`
- `src/structures/ips_section_resource_map.ts` — drop `IPSSectionSummaryIPSCompositionFilter`, `getSummaryIPSCompositionFilterForSection`, and the IPS-tier import
- `src/generators/fhir_summary_generator.ts` — drop IPS-tier branches in `readBundleAsync` and `getRemainingResourcesFromCompositionBundle`
- `tests/full_record/full_record.test.ts` — drop `SUMMARY_IPS_COMPOSITION_SECTIONS` env-var setup
- `tests/fhir-summary-bundle/fhir-summary-bundle.test.ts` — drop env-var setup; update `expectedResources` to include `ClinicalImpression`, `DeviceUseStatement`, `Device` (the IPS Compositions in `required-resource-bundle.json` for FUNCTIONAL_STATUS, MEDICAL_DEVICES, PREGNANCY_HISTORY, and PATIENT no longer cover those sections)
- `README.md` — remove `SUMMARY_IPS_COMPOSITION_SECTIONS` doc + the "IPS-Specific Composition" priority bullet

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (auto-applied via lint-staged on commit)
- [x] `npm test` — failing test set is **byte-identical** to stock `main` (10 pre-existing locale/date-formatting failures across `narrativeGenerator.test.ts`, `fhir-summary-bundle.test.ts`, `full_record.test.ts`; not caused by this PR)
- [x] Targeted `requiredResources` test passes with the updated expected list
- [x] Repo-wide grep confirms no `SUMMARY_IPS_COMPOSITION_SECTIONS` / `IPSSectionSummaryIPSCompositionFilter` / `getSummaryIPSCompositionFilterForSection` / `IPS_SUMMARY_IPS_COMPOSITION_TYPE_SYSTEM` references remain outside the design spec
- [ ] Reviewer: confirm no downstream consumer relies on `SUMMARY_IPS_COMPOSITION_SECTIONS` before merge

## Note on pre-existing test failures

10 tests fail identically on `main` and on this branch — they appear to be locale-sensitive date-formatting assertions (e.g. `03/15/2025` vs `15/03/2025`). Fixing them is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)