### PR TITLE
EA-2136 sync architecture instruction files from org baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @icanbwell/fhir-team
+
+# Architecture instruction files owned by Enterprise Architecture
+/AGENTS.md @icanbwell/enterprise-architecture
+/CLAUDE.md @icanbwell/enterprise-architecture

--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -1,0 +1,18 @@
+name: 'Commit Message Check'
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  push:
+    branches: [main, 'releases/*']
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check For Issue Key
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^(Bump|Merge|Revert|Reapply|build\(deps(-dev)?\): bump|([A-Z]+-[0-9]+))\s+.+'
+          flags: 'gm'
+          error: 'Commit message must begin with a JIRA Issue Key: e.g. HP-123 <message>'

--- a/.github/workflows/pr-architecture-review.yml
+++ b/.github/workflows/pr-architecture-review.yml
@@ -1,0 +1,22 @@
+name: PR Architecture Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  call-review:
+    uses: icanbwell/.github/.github/workflows/pr-architecture-review-reusable.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      base_ref: ${{ github.event.pull_request.base.ref }}
+      head_ref: ${{ github.event.pull_request.head.ref }}
+      head_sha: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      bwell_dev_pat: ${{ secrets.BWELL_DEV_PAT }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,487 @@
+# icanbwell - AI Agent Instructions
+
+> **Scope:** Organization-wide baseline. Applies to all repositories in the icanbwell GitHub organization.
+> **Owner:** Enterprise Architecture (@icanbwell/enterprise-architecture)
+> **Precedence:** This file sets the floor. Repo-level instruction files (copilot-instructions.md, CLAUDE.md) may add stricter requirements or repo-specific context but must not weaken or contradict these directives. If there is a conflict, this baseline wins. Repo-level overrides may only tighten rules, never loosen them. Any true exception to this baseline requires EA approval with documented rationale, scope, owner, JIRA ticket, and expiry date.
+
+---
+
+## Platform Identity
+
+You are working in the icanbwell GitHub organization. b.well is a cloud-native, multi-tenant, microservice-based, event-driven distributed system. It is a healthcare data platform operating under HIPAA compliance requirements. The platform is FHIR-native and exposes capabilities through a federated GraphQL gateway.
+
+This is a distributed system. Design accordingly. Services are independently deployable, communicate asynchronously by default, and own their private datastores. The shared platform system-of-record is the FHIR server, accessed only via approved APIs and contracts (FHIR APIs, federated graph, events). Workflows that span multiple services use sagas and event choreography, not distributed transactions or synchronous orchestration chains.
+
+Treat these as hard constraints, not suggestions. Code that violates tenant isolation, leaks PHI, bypasses the gateway, introduces unapproved technology, or creates tight coupling between services is incorrect regardless of whether it compiles and passes tests.
+
+---
+
+## Architecture Non-Negotiables
+
+### Event-Driven First
+Default to asynchronous communication via Kafka with CloudEvents. If you are choosing a synchronous call between services, document why asynchronous does not work. Do not default to REST calls for cross-service workflows. Synchronous service-to-service calls create temporal coupling - the caller blocks, the callee must be available, and cascading failures propagate. Use sync only for queries where the response is needed immediately to serve a user request and the data cannot be pre-materialized.
+
+### Distributed Systems Patterns
+
+**Sagas, not distributed transactions.** Multi-service workflows use the saga pattern with compensating actions for rollback. Each step publishes an event on success; each step has a defined compensation if a downstream step fails. There is no distributed transaction coordinator. If you are implementing a saga:
+- Each step must be independently completable and compensatable.
+- Compensating actions must be idempotent (they may execute more than once).
+- Use Kafka topics for saga events. Do not use synchronous callback chains disguised as a saga.
+- The saga must be resilient to out-of-order delivery and duplicate events.
+- Document the saga flow, including the compensation path, in an ADR.
+
+**Choreography over orchestration for cross-service workflows.** Services react to events they care about rather than being directed by a central orchestrator. If you find yourself building a service whose sole purpose is calling other services in sequence and waiting for responses, you are building synchronous orchestration. Redesign it as event choreography where each service publishes domain events and downstream services subscribe. Orchestration is acceptable within a bounded context when it stays async, avoids request-reply chains, and does not become a cross-domain god orchestrator. If orchestration crosses domain boundaries or requires request-reply chains to function, redesign it as choreography.
+
+**Service data ownership.** Services must not read from or write to another service's private datastore directly. The platform system-of-record is the FHIR server; services interact with it through approved APIs and contracts (FHIR APIs, federated graph, events), not by directly accessing its underlying storage. If you need data owned by another service, consume it via events (preferred) or query it via the service's public API. No shared private databases between services.
+
+**Kafka usage patterns:**
+- Use CloudEvents envelope format for event metadata.
+- Partition keys must ensure ordering for the same entity (typically entity ID or tenant + entity ID).
+- Consumers must be idempotent. Assume at-least-once delivery.
+- Use consumer groups appropriately for scaling. Understand that repartitioning affects ordering guarantees.
+- Dead letter topics for messages that fail processing after retries.
+- Do not use Kafka as a request-reply mechanism. That is synchronous communication disguised as async.
+
+**Eventually consistent, not immediately consistent.** In a distributed system, cross-service data will be eventually consistent. Design read paths and user experiences to accommodate this. Do not build features that assume immediate consistency across service boundaries. If strong consistency is required within a bounded context, that logic belongs in a single service.
+
+### FHIR-Native Data Modeling
+Use standard FHIR resources before inventing custom schemas. Model workflow state using FHIR-native resources where applicable. Extensions are a last resort - if you need one, flag it as an architectural decision requiring review, not a casual convenience.
+
+FHIR data modeling decisions go through the FDR (FHIR Design Review) process. If your change introduces new FHIR resource usage or modifies how existing resources are structured, reference the relevant FDR or flag that one is needed.
+
+### Federated GraphQL Gateway
+Client-facing capabilities go through the federated graph. Do not create point-to-point service APIs that bypass the gateway for client access. Public API changes and schema evolution require breaking-change discipline and a Tech Design Review.
+
+### Tenant Isolation
+Tenant isolation is mandatory on every persistence model and every query path. This is a correctness constraint, not a best-effort optimization. Every read and write must enforce tenant ownership boundaries. If you are adding a new data access path, verify tenant filtering is present. If you cannot confirm it, flag it.
+
+### No Unapproved Technology
+Do not introduce new datastores, caches, queues, search engines, observability sinks, vendors, or significant libraries without checking `approved-tech.yaml` first. The approved technology list lives in the org-level `icanbwell/.github` repository and is distributed to repos via the policy sync workflow. If the technology is not listed, the change requires a Tech Design Review with EA. Infrastructure changes go through Terraform PRs - never provide console instructions or manual steps as the solution.
+
+---
+
+## Object-Oriented Analysis and Design
+
+### Composition Over Inheritance
+Build behavior by composing small, focused objects. Do not build deep class hierarchies. If you are extending a base class, evaluate whether delegation or composition would be cleaner. Keep inheritance to a maximum of two levels. If you are going deeper, refactor to composition.
+
+### Program to Interfaces, Not Implementations
+Define behavior through protocols (Python), interfaces (TypeScript/Java), or abstract base classes. Consumers depend on the abstraction, never the concrete class. Use structural typing (Python Protocol, TypeScript interfaces) to define contracts. Favor protocols over subclassing.
+
+### Vendor Integrations Behind Abstractions
+When integrating a vendor or third-party service, define an interface for the *capability* the vendor provides, not the vendor itself. The vendor is an implementation detail behind an adapter. If the vendor changes tomorrow, the blast radius should be one adapter, not every file that touches that capability.
+
+Bad: `ValidicDeviceDataService`, `ValidicClient`, `ValidicTransformer` spread across the codebase.
+Good: `DeviceDataProvider` interface with a `ValidicDeviceDataAdapter` as the concrete implementation.
+
+### Encapsulate What Varies
+Identify what changes and isolate it behind an interface. Use the Strategy pattern when behavior varies based on context - inject a strategy rather than adding conditionals or subclass overrides. Use the Template Method pattern when the overall algorithm is fixed but individual steps vary.
+
+### No God Objects
+If a class has more than one axis of change or knows about too many concerns, decompose it. Single Responsibility applies at the class level, not just the method level.
+
+### Value Objects for Domain Concepts
+Use immutable value types for concepts like identifiers, measurements, date ranges, and money. Equality by value, not identity. Use frozen dataclasses (Python), readonly types (TypeScript), or records (Java).
+
+### Law of Demeter
+Do not chain through objects. If you are writing `a.b.c.doThing()`, something is leaking its internals. Ask, don't reach.
+
+---
+
+## SOLID Principles
+
+### Single Responsibility
+One reason to change per class or module. If a function does transformation AND persistence, split it. If a service handles both business logic and infrastructure concerns, separate them.
+
+### Open/Closed
+Extend behavior through new classes, not by modifying existing ones. No growing conditional chains - use strategy pattern or composition for extensibility.
+
+### Liskov Substitution
+Any implementation of an interface must be fully swappable without breaking callers. Do not override methods to throw NotImplementedError or silently change expected behavior.
+
+### Interface Segregation
+Keep interfaces small and focused. If a consumer only needs read access, do not force it to depend on an interface that also includes write methods. Split large interfaces into focused ones.
+
+### Dependency Inversion
+Depend on abstractions at module and service boundaries. Inject dependencies through constructors. Never instantiate infrastructure inside business logic. Never use service locators when constructor injection is available.
+
+---
+
+## Architectural Boundaries
+
+### Separate Domain from Infrastructure
+
+Keep business logic independent of frameworks, databases, and external services. Domain logic should not import infrastructure concerns. Infrastructure adapts to domain interfaces, not the other way around.
+
+In repos using ports and adapters (hexagonal architecture), respect the layering:
+- **Domain layer**: Business logic, domain models, port interfaces. No infrastructure imports.
+- **Application layer**: Use case orchestration, service interfaces. Coordinates domain and ports.
+- **Infrastructure layer**: Adapters implementing ports (database, HTTP clients, message brokers, vendor integrations).
+
+If the repo does not use explicit hexagonal structure, follow the principle spiritually: domain code exposes interfaces, infrastructure code implements them. Do not let database schemas, REST frameworks, or vendor SDKs leak into business logic.
+
+---
+
+## General Design Principles
+
+### DRY, Pragmatically
+Prefer duplication over the wrong abstraction. Extract shared logic only when the pattern is stable and repeats across multiple call sites, or when there is clear semantic reuse. Premature abstraction creates coupling that is harder to undo than duplicated code. If you are unsure whether to extract, leave it duplicated until the pattern is clear.
+
+### Explicit Over Clever
+Readable code over compact code. Name things for what they do, not how they are implemented. Prefer explicit types and contracts at boundaries over inference.
+
+### Fail Fast
+Validate inputs at the boundary and reject early. Do not let bad data propagate through layers. Typed and structured errors at boundaries, not stringly-typed error messages or raw exception forwarding.
+
+### No Hidden Global State
+All dependencies must be explicit and injectable. No module-level singletons that hold state. No implicit service locators.
+
+### Idempotency by Default
+Any consumer that processes events or handles retries must be idempotent. This is not optional in a distributed system with at-least-once delivery. Duplicate processing must produce the same result. Use idempotency keys, deduplication checks, or upsert semantics. Design every Kafka consumer, webhook handler, and retry-capable operation with the assumption that it will be called more than once with the same input.
+
+### Minimal Diff
+Make the smallest change that satisfies the requirement. Do not rename, reformat, or reorganize unrelated code in the same PR. Do not refactor modules you were not asked to change. Scope the change to what was requested.
+
+---
+
+## Modern, Idiomatic Code
+
+Use current language idioms for the repo's language version. Do not write legacy-style code.
+
+**Java:** Use records for data carriers, not POJOs with boilerplate getters/setters. Use sealed interfaces for closed type hierarchies. Use pattern matching where available. Use `var` for local variables when the type is obvious from the right side. Use streams and Optional appropriately, not for every operation.
+
+**Python:** Use dataclasses or Pydantic models, not manual dict manipulation. Use type hints everywhere. Use structural pattern matching (3.10+) where it improves clarity. Use `Protocol` for structural typing. Use `async`/`await` for IO-bound operations in async services.
+
+**TypeScript:** Use discriminated unions for variant types, not type casting chains. Use strict mode. Use `readonly` and `as const` where appropriate. Use modern `satisfies` operator for type-safe object literals. Use optional chaining and nullish coalescing instead of manual null checks.
+
+---
+
+## Security
+
+### PHI/PII Protection
+Never put PHI or PII in logs, test fixtures, example payloads, comments, commit messages, PR descriptions, or screenshots. Use synthetic or redacted data by default. If you need realistic test data, use a generator that produces synthetic records.
+
+### Authentication and Authorization
+All auth flows use OAuth/OIDC. No custom authentication schemes. No hardcoded credentials, tokens, or secrets in code, configuration files, or tests.
+
+---
+
+## Testing
+
+### Testing Is Part of the Change
+Every behavioral change ships with tests. Tests are not a follow-up task.
+
+### Parameterized Tests
+Use parameterized tests (Jest `test.each`, pytest `@pytest.mark.parametrize`, JUnit `@ParameterizedTest`) for any function with more than two input variations. Data-driven test cases, not copy-pasted test methods with one value changed.
+
+### Arrange-Act-Assert
+Structure every test with clear setup, execution, and verification phases. One behavior per test. Multiple asserts are fine when they verify that single behavior.
+
+### Mock Only at External Boundaries
+Mock external services, databases, and third-party APIs. Do not mock internal implementation details. If you need extensive mocking to test a unit, the design is too coupled - fix the design, not the test.
+
+### Test Error Paths
+Test failure modes, error handling, retries, and edge cases explicitly. Do not test only the happy path.
+
+### Contract Tests at Boundaries
+API request/response shapes, event schemas, and external integration contracts must have contract tests. When you change a public API or event schema, update the contract test in the same PR.
+
+### Tenant Isolation in Integration Tests
+Integration tests must verify that tenant boundaries are enforced. Cross-tenant data leakage is a correctness bug, not a nice-to-have test case.
+
+### Test Behavior, Not Implementation
+Assert on what happened, not how it happened internally. Tests should survive refactoring of internals without breaking.
+
+---
+
+## Event Contracts
+
+Event schemas are real contracts with consumers. Treat them accordingly.
+
+### Schema Evolution
+Additive changes only unless there is an explicit exception with a migration plan approved by EA. Do not remove fields, rename fields, or change field types on existing events.
+
+### Contract Co-Location
+If you add or modify an event, update the AsyncAPI specification (or the canonical contract definition) as part of the same change. Do not ship event changes without updating the contract.
+
+---
+
+## Operational Realism
+
+Services run in a distributed environment, fail independently, and must handle partial failures gracefully.
+
+### Timeouts and Retries
+Every external call must have an explicit timeout. Retries must use exponential backoff with jitter. Do not use unbounded retries. Implement DLQ (dead letter queue) patterns for messages that fail after retry exhaustion.
+
+### Circuit Breakers
+Use circuit breaker patterns for synchronous calls to external services. When a dependency is failing, fail fast rather than accumulating blocked threads and cascading the failure upstream.
+
+### Performance Awareness
+Do not introduce "fetch the entire record" behavior unless it is an explicit, reviewed decision. Be aware of N+1 query patterns, unbounded list fetches, and full-collection scans. Healthcare records can be large - assume they are. In a microservice architecture, a single slow query can cascade through downstream consumers via backpressure.
+
+### Observability Is a Deliverable
+OpenTelemetry tracing propagation must be maintained across service boundaries. Trace context must flow through Kafka headers, HTTP headers, and any other transport. Logs must be structured (JSON) with correlation IDs. Metrics must be meaningful, not just counters. If you add a new service interaction or failure mode, add the corresponding observability. In a distributed system, observability is how you debug production - it is not optional.
+
+---
+
+## Architecture Decision Records
+
+When you make a non-trivial implementation decision - choosing a caching strategy, selecting a library, picking an architectural pattern for a new component, deciding between implementation approaches - create an ADR in the repo's `adrs/` directory.
+
+### When to Write an ADR
+- Introducing a new dependency or library
+- Choosing between competing implementation approaches (e.g., Caffeine vs. Kafka Streams/RocksDB for state management)
+- Adding a new architectural pattern not previously used in the repo
+- Making a significant trade-off that future developers will need to understand
+
+### ADR Discipline
+Use the MADR (Markdown Any/Architectural Decision Records) format from https://adr.github.io/madr/. The canonical template is in the repo's `adrs/` directory or in the org-wide `.github` repository. Show your work. The value of an ADR is the options considered and the reasoning, not just the conclusion. A reviewer should be able to understand why you chose Option 2 over Option 1 without asking. If there is an idiomatic or platform-standard way to solve the problem, prefer it over introducing something new. Document why if you diverge.
+
+---
+
+## Process References
+
+These are the governing processes. If your change falls into one of these categories, reference or initiate the appropriate process.
+
+- **New technology, vendor, or significant pattern:** Requires a Tech Design Review with EA. Create a JIRA ticket (type: "Tech Design Review") in the EA project with a link to your Technical Design Document.
+- **FHIR data modeling decisions:** Requires an FDR (FHIR Design Review). Create or update the FDR Confluence page and get FHIR SME approval.
+- **Public API changes, cross-team impact, significant system changes:** Requires a Tech Design Review.
+- **Repo-local implementation decisions:** Document in an ADR in the repo's `adrs/` directory.
+
+If you are unsure whether your change requires a review, apply the "Is it NEW?" test: are you introducing a new technology, a new vendor, or a new pattern that has not been used in this codebase before? If yes, it needs EA review.
+
+---
+
+## Agent Behavior
+
+### Plan Before Acting
+Before making non-trivial changes, propose a short plan. Call out risks: does this touch tenant isolation, PHI, public contracts, event schemas, or introduce a new dependency? Identify which governing artifacts (Tech Design Doc, FDR, ADR, AsyncAPI) are relevant before writing code. Before coding, briefly restate the applicable constraints you are following for this change (tenancy, PHI, contracts, dependencies).
+
+### Diagnose Before Escalating
+When encountering failures or blocked operations, diagnose the actual root cause before proposing solutions that require elevated permissions, org admin intervention, or process escalation. Simple configuration issues (missing credential setup, incorrect paths, malformed syntax) are not permission problems. Read logs carefully. Check for obvious mistakes first: Are you using the right token variable? Is the remote URL configured? Did the command actually fail or just warn?
+
+Do not jump to "this needs org admin" or "this requires a PAT" without evidence that the current approach is architecturally insufficient. If a similar workflow works elsewhere in the codebase, investigate what that workflow does differently before concluding new infrastructure is needed.
+
+### Respect System Constraints
+Understand the constraints of the system you are working in. If branch protection requires reviews, you cannot merge - do not repeatedly offer to merge. If CI checks are failing, you cannot bypass them - do not offer workarounds. If a process requires approval, you cannot skip it - do not suggest shortcuts.
+
+When a user tells you an action is blocked or explains a constraint, internalize it. Do not re-propose the same blocked action with different wording. If you are unsure whether a constraint applies, ask once. If the answer is "no, that won't work", do not ask again or try to find a loophole.
+
+### Don't Guess Commands
+Find and use the repo's canonical build, test, and lint commands. Check the Makefile, package.json scripts, build.gradle, or Pipfile. If the commands are unclear, say so and point to where you looked. Do not invent commands.
+
+### Don't Introduce Dependencies Casually
+Check `approved-tech.yaml` before adding any new dependency. If the dependency is not listed, flag it for review. Do not assume a library is approved because it is popular.
+
+### Reference Governing Artifacts
+If your change touches a public API, event contract, or cross-service behavior, reference the governing document (Tech Design Doc, FDR, ADR, AsyncAPI spec) in the PR description or commit message. If no governing artifact exists and one should, say so.
+
+### Look for Abstraction Opportunities
+Before implementing, consider whether the change introduces a concept that should be abstracted. If you are adding a vendor integration, wrap it behind a capability interface. If you are adding branching logic, consider whether a strategy pattern is more appropriate. If you see existing code that couples to a concrete implementation where an interface would reduce blast radius, flag it.
+
+### Flag What Looks Wrong
+If you encounter code that violates these principles - tenant isolation missing on a query path, PHI in test fixtures, a vendor name baked into business logic, a synchronous call where an event would be appropriate - flag it in a comment. Do not silently work around it.
+
+### Code Ownership
+Do not add "Co-Authored-By", "Generated by", or any other AI attribution to commits, PRs, or code comments. Engineers own their code regardless of what tool assisted in writing it. The tool is irrelevant. The author on the commit is the owner.
+
+
+### Branch Naming
+Branch names must follow the pattern: `{initials}-{project}-{ticket-number}`
+
+**Format:** `XX-PROJ-123` where:
+- `XX` = your initials (e.g., WF for Bill Field)
+- `PROJ` = JIRA project key (EA, HP, PAY, etc.)
+- `123` = ticket number
+
+**Valid branch names:**
+```
+WF-EA-2136
+JD-HP-456
+SK-PAY-789
+```
+
+**Invalid branch names:**
+```
+feature/add-new-feature
+fix-bug-123
+EA-2136 (missing initials)
+feature/ai-dev-infrastructure-item-1
+```
+
+Do not use conventional branch prefixes like `feature/`, `fix/`, `bugfix/`, or `hotfix/`. The JIRA ticket key provides all necessary context.
+### Commit Messages
+Every commit message must begin with a JIRA issue key. Do not use conventional commit prefixes like `feat:`, `fix:`, `chore:`, or similar. The JIRA key is the only required prefix.
+
+**Valid commit message format:**
+```
+PROJ-123 implement user authentication API
+HP-456 resolve timeout in data sync service
+EA-789 add FHIR resource validation
+```
+
+**Invalid commit messages:**
+```
+feat: implement user authentication API
+fix(api): resolve timeout issue
+chore: update dependencies
+```
+
+**Exceptions:** The following patterns are allowed without JIRA keys:
+- Automated dependency updates: `Bump version`, `build(deps): bump library-name`
+- Git operations: `Merge`, `Revert`, `Reapply`
+
+All commits are validated automatically. If you do not have a JIRA ticket for your work, create one before committing.
+
+### Working with icanbwell Infrastructure
+
+**Atlassian (JIRA & Confluence):** https://icanbwell.atlassian.net/  
+**Slack Workspace:** icanbwell
+
+#### Creating JIRA Tickets
+
+Use the Atlassian MCP to create tickets programmatically. The MCP server connects via `plugin:atlassian:atlassian`.
+
+**Required steps:**
+1. Get cloudId: `mcp__plugin_atlassian_atlassian__getAccessibleAtlassianResources()`
+2. Create issue: `mcp__plugin_atlassian_atlassian__createJiraIssue(cloudId, projectKey, issueTypeName, summary, description, parent)`
+
+**Example:**
+```
+cloudId: "<from-step-1-above>"  # Use getAccessibleAtlassianResources() to get current value
+projectKey: "EA" (Enterprise Architecture) or team-specific project
+issueTypeName: "Task", "Story", "Bug"
+parent: "EA-XXXX" (for linking to epics)
+```
+
+**Common Projects:**
+- EA: Enterprise Architecture
+- HP: Health Plan projects  
+- PAY: Payment projects
+- RNGR: Clinical projects
+
+If Atlassian MCP tools are not available:
+1. Check MCP connection: `claude mcp list`
+2. Tool naming pattern: `mcp__plugin_atlassian_atlassian__[tool_name]`
+3. Search tools: Use ToolSearch to find `mcp__plugin_atlassian` tools
+4. Restart if needed: Session restart may be required to load MCP tools
+
+#### Reading Confluence Pages
+
+Use `mcp__plugin_atlassian_atlassian__getConfluencePage(cloudId, pageId, contentFormat)` to read documentation.
+
+**Finding pages:** `mcp__plugin_atlassian_atlassian__searchConfluenceUsingCql(cloudId, cql, limit)`
+
+Common spaces:
+- ENTARCH: Enterprise Architecture documentation
+- DEV: Developer documentation  
+- OPS: Operations & infrastructure
+
+#### Slack Integration
+
+Use Slack MCP for posting messages and searching conversations.
+
+**Post messages:** `mcp__plugin_slack_slack__slack_send_message(channel_id, text)`  
+**Search:** `mcp__plugin_slack_slack__slack_search_public(query, content_types, limit)`
+
+Common channels:
+- #tech-enterprise-architecture: EA team channel
+- #tech-dev: Engineering announcements
+- #possible-sdk-impact: SDK change notifications
+
+
+
+### Schema and Client Resilience
+Assume clients may receive unknown enum values and new fields at any time. Design for forward compatibility. Do not write exhaustive enum switches without a default/unknown handler. Do not fail on unrecognized fields. GraphQL schema evolution and event schema evolution must be additive - new fields and enum values must not break existing consumers.
+
+---
+
+## Code Style
+
+Follow whatever linter, formatter, and static analysis configuration exists in the repo. Do not duplicate what automated tooling already enforces. These instructions are for architectural and design decisions that linters cannot catch.
+
+
+----
+
+## Terraform
+
+Create simple modules and compose from them
+    A base module should do just as much as needed to create a single resource, e.g. an S3 bucket, a VPC private link, 
+    Compose more complex infrastructure from these base modules
+    You should never create a resource directly in the root module
+Avoid code that creates singletons
+    Never expect you will only create one instance of an object
+    Use Terraform nested data structures and for_each to allow multiple instantiation of a resource/module with different input values
+Start from the API and work toward the implementation
+    Think first of how a user/engineer will add a new instance of the infrastructure component, what values can/should they provide?
+        Make it as simple as possible
+    From these inputs, build toward the desired implementation
+        Make use of data sources where possible instead of requiring the user to provide the value(s)
+    If the inputs start getting complex, it is a sign to refactor your design
+Never use terraform_remote_state
+    This pattern introduces a cascading dependency between projects
+        A single terraform/tofu plan is no longer sufficient for a change, you have to plan/apply the dependency project to get the most updated state
+    Use data sources to fetch the live current state of the infrastructure
+    Use AWS Tags as labels and filter on those labels in data sources
+        Example: subnets to be used for a transit gateway attachment are tagged bwell/transit-gateway = main
+        Tag names should be prefixed with bwell/
+Use of OpenTofu quality-of-life features are encouraged
+    OpenTofu adds a number of features on top of Terraform, use them
+Do not use count
+    Resources created by count have the collection index as part of the resource key
+        Creates problems when selectively cleaning resources
+    Use enabled meta-argument, or
+    Use for_each = { for v in var.vpc_names : v => v }
+When updating modules in this repository, always increment the module version and the module README.
+
+<!-- SYNC:PRESERVE-BELOW (do not edit this line -- content below survives the AGENTS.md sync) -->
+
+<!-- REPO-SPECIFIC ADDENDUM — complaint-parser only. Everything above this line is the org-wide
+     baseline, synced from icanbwell/.github (see CODEOWNERS, PR review by @icanbwell/enterprise-architecture).
+     This section is preserved across syncs automatically by the SYNC:PRESERVE-BELOW sentinel above
+     (icanbwell/.github .github/workflows/sync-agents-md.yml) -- no manual restoration needed on
+     future sync PRs. -->
+
+## complaint-parser: repo-specific pointers
+
+Two things below are always relevant at the start of a session in this repo — check them early,
+not just when a task obviously needs them:
+
+- **`sessions/index.md`** — a pending → complete lifecycle for self-contained implementation
+  plans. Read it first if you're picking up work with no other specific instruction; it names a
+  recommended next session.
+- **`.claude/guidelines/index.md`** — repo-specific process guidance (deploying, etc.), organized
+  so each file is read only when the task at hand actually needs it. Not duplicated here to avoid
+  this baseline file growing unbounded as more guidance accumulates.
+
+<!-- SYNC:PRESERVE-BELOW (do not edit this line -- content below survives the AGENTS.md sync) -->
+
+## Repo-Specific: ai-health-optimization — Cross-Repo Impact Checklist
+
+<!-- Everything above this line is the org-wide baseline, synced from icanbwell/.github
+     (see CODEOWNERS, PR review by @icanbwell/enterprise-architecture). This section is
+     preserved across syncs automatically by the SYNC:PRESERVE-BELOW sentinel above
+     (icanbwell/.github .github/workflows/sync-agents-md.yml) -- no manual restoration
+     needed on future sync PRs. -->
+
+> Repo-specific context, additive to the baseline above. When changing aggregation, unit handling, validation, scoring, or composition output, check **both ends** of the dependency chain before merging:
+
+- **Upstream — `device-codex`** (GitHub `icanbwell/device-codex`, pip package `devicecodex`): the source of truth for LOINC metadata, unit families, canonical units, valid ranges, and FHIR unit/code normalization (`interop.normalize_fhir_unit`, `is_plausible_unit`, `normalize_code`; `registry.get_metric_by_code`). Fix unit/range/code-alias gaps upstream there rather than patching locally; this repo should consume device-codex, not re-implement it.
+- **Downstream — `bwell-databricks`** (GitHub `icanbwell/bwell-databricks`): within that repo, `bundle/device-data-ingest-job/src/bwell/device_data_ingest_job/health_insights.py` calls `aihealthoptimization.pipeline.create_compositions_from_observations` and writes the returned Compositions to FHIR. It **exact-pins** `aihealthoptimization`/`devicecodex` in that bundle's `requirements.txt`, so scoring/value changes reach production only when the pin is bumped — coordinate that as a score-recompute / data-quality event, not a silent rollout. Keep the pipeline signature and composition keys (`device_metrics` + body-system names) stable.
+
+<!-- SYNC:PRESERVE-BELOW (do not edit this line -- content below survives the AGENTS.md sync) -->
+
+## Repo-Specific: ai-care-gap-scoring — Context
+
+<!-- Everything above this line is the org-wide baseline, synced from icanbwell/.github
+     (see CODEOWNERS, PR review by @icanbwell/enterprise-architecture). This section is
+     preserved across syncs automatically by the SYNC:PRESERVE-BELOW sentinel above
+     (icanbwell/.github .github/workflows/sync-agents-md.yml) -- no manual restoration
+     needed on future sync PRs. -->
+
+> Repo-specific context, additive to the baseline above.
+
+- **Purpose & phase:** Care gap closure **propensity scoring**. Currently **Phase 0 — feasibility**: produce PHI-safe aggregate feasibility/EDA reports (no model, no FHIR writes) to decide GO/NO-GO per measure. First measure: Breast Cancer Screening. See `docs/superpowers/specs/` and `docs/superpowers/plans/`.
+- **Data source — Databricks.** Reads normalized FHIR from `silver.fhir_lite.*` and quality-measure data from `bronze.dqm.*` via **`bwell-databricks-valet`** (`get_spark()` + env→catalog resolution). Catalogs are env-scoped (`nophi_dev` test, `silver_dev`/`silver` dev/prod). Do not read another service's private datastore directly.
+- **PHI is paramount.** Every emitted artifact is an aggregate only (counts/rates/correlations/binned distributions) with small-cell suppression (n<11) and no identifiers or exact dates. An output guard fails the run on PHI-like content. Never write row-level patient data to disk or logs.
+- **Eventual downstream (deferred to a later phase):** propensity scores will be written to the FHIR server as **`RiskAssessment`** resources, pending a new FDR ("Care Gap Propensity Score"). Nothing is written to FHIR in Phase 0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,0 +1,28 @@
+# icanbwell - Copilot Instructions
+
+You are working in a cloud-native, multi-tenant, HIPAA-compliant healthcare platform. The platform is FHIR-native, event-driven (Kafka + CloudEvents), and exposes capabilities through a federated GraphQL gateway.
+
+## Hard Constraints
+- Tenant isolation is mandatory on every data access path. Not optional.
+- No PHI/PII in logs, test fixtures, example data, comments, or PR descriptions.
+- No new technology, vendors, or patterns without checking approved-tech.yaml and EA review.
+- Public API changes require a Tech Design Review.
+- Event-driven first. Default to async via Kafka. Justify sync.
+- Client-facing access goes through the federated GraphQL gateway. No bypass.
+
+## Design Defaults
+- Program to interfaces, not implementations. Vendor integrations behind capability abstractions.
+- Composition over inheritance. Strategy pattern over growing conditionals.
+- Dependency injection at boundaries. No hidden global state.
+- Idempotent consumers. Assume at-least-once delivery.
+- Parameterized tests for functions with more than two input variations.
+- Mock only at external boundaries.
+
+## Before Coding
+- Find and use the repo's canonical build/test/lint commands. Do not guess.
+- Propose a plan for non-trivial changes. Call out tenancy, PHI, contract, and dependency risks.
+- Check approved-tech.yaml before introducing any dependency.
+- If your change touches public API, events, or cross-service behavior, reference the governing artifact (TDD, FDR, ADR, AsyncAPI).
+
+## Repo-Specific Instructions
+Check .github/copilot-instructions.md in the specific repository for repo-level context, commands, and additional guidelines that extend these org-wide instructions.

--- a/policies/approved-tech.yaml
+++ b/policies/approved-tech.yaml
@@ -1,0 +1,372 @@
+# Approved Technology Stack - icanbwell
+# Owner: Enterprise Architecture
+# Last Updated: 2026-03-03
+# Version: 1.0.0
+#
+# Purpose: Centralized registry of approved technologies, frameworks, and tools.
+# Any addition requires Tech Design Review with EA approval.
+#
+# Enforcement:
+#   - severity: "warn" = Flag for review, does not block
+#   - severity: "error" = Blocks PR merge, requires exception approval
+#   - Phase 2 enforcement starts at "warn" for all categories
+
+---
+version: "1.0.0"
+updated: "2026-03-03"
+enforcement:
+  defaultSeverity: "warn"
+  exceptionProcess: "Tech Design Review with EA (JIRA ticket in EA project)"
+
+categories:
+  # ============================================================================
+  # Languages
+  # ============================================================================
+  languages:
+    severity: "warn"
+    approved:
+      - name: "TypeScript"
+        versions: ["5.x"]
+        notes: "Preferred for new Node.js services"
+
+      - name: "JavaScript"
+        versions: ["ES2022+"]
+        notes: "Approved for Node.js services alongside TypeScript"
+
+      - name: "Python"
+        versions: ["3.11", "3.12"]
+        notes: "Preferred for data pipelines, AI/ML services"
+
+      - name: "Java"
+        versions: ["17", "21"]
+        notes: "Spring Boot services, FHIR processing"
+
+      - name: "Kotlin"
+        versions: ["1.9+"]
+        notes: "Mobile SDKs, Android native"
+
+      - name: "Swift"
+        versions: ["5.9+"]
+        notes: "iOS SDK only"
+
+      - name: "HCL"
+        versions: ["Terraform 1.5+"]
+        notes: "Infrastructure as Code only"
+
+  # ============================================================================
+  # Frameworks & Libraries
+  # ============================================================================
+  frameworks:
+    severity: "warn"
+    approved:
+      # Backend Frameworks
+      - name: "NestJS"
+        category: "backend"
+        versions: ["10.x"]
+        notes: "Preferred Node.js backend framework"
+
+      - name: "FastAPI"
+        category: "backend"
+        versions: ["0.109+"]
+        notes: "Preferred Python backend framework"
+
+      - name: "Flask"
+        category: "backend"
+        versions: ["3.x"]
+        notes: "LEGACY ONLY - Do not use for new services. Migrate to FastAPI."
+        legacy: true
+
+      - name: "Django"
+        category: "backend"
+        versions: ["4.x", "5.x"]
+        notes: "Legacy bwell-platform only. Do not use for new services."
+        legacy: true
+
+      - name: "Spring Boot"
+        category: "backend"
+        versions: ["3.x"]
+        notes: "Java microservices standard"
+
+      # Frontend Frameworks
+      - name: "React"
+        category: "frontend"
+        versions: ["18.x"]
+        notes: "Web UI standard"
+
+      - name: "React Native"
+        category: "mobile"
+        versions: ["0.73+"]
+        notes: "Mobile app standard"
+
+      # AI/ML Frameworks
+      - name: "LangChain"
+        category: "ai-ml"
+        versions: ["0.1.x"]
+        notes: "LLM orchestration, agent frameworks"
+
+      - name: "LangGraph"
+        category: "ai-ml"
+        versions: ["0.0.x"]
+        notes: "Stateful agent workflows"
+
+  # ============================================================================
+  # Data Storage
+  # ============================================================================
+  datastores:
+    severity: "warn"
+    approved:
+      - name: "FHIR Server"
+        type: "document"
+        implementation: "MongoDB"
+        notes: "Platform system-of-record; access via FHIR APIs only"
+
+      - name: "MongoDB"
+        type: "document"
+        versions: ["7.x"]
+        notes: "Service-private datastores; tenant isolation mandatory"
+
+      - name: "PostgreSQL"
+        type: "relational"
+        versions: ["15.x", "16.x"]
+        notes: "First-class approved relational store, incl. operational run/FSM state with JPA + Flyway migrations (the clinical-reasoning-orchestrator uses PostgreSQL). Choose relational (PostgreSQL) vs document (MongoDB) by workload, not by default — see decision-guides/datastore-selection.md. A new-service datastore still requires a Tech Design Review; tenant isolation mandatory."
+
+      - name: "Elasticsearch"
+        type: "search"
+        versions: ["8.x"]
+        notes: "Search and analytics; requires Tech Design Review for new use cases"
+
+      - name: "Neo4j"
+        type: "graph"
+        versions: ["5.x"]
+        notes: "Graph database for data operations; requires Tech Design Review for new use cases"
+
+      - name: "ClickHouse"
+        type: "analytics"
+        versions: ["23.x", "24.x"]
+        notes: "OLAP database for analytics and time-series data. Also an active EA-approved track (EA-2126) as a hybrid FHIR storage backend for resources that exceed MongoDB's 16MB BSON limit (e.g. Group at 1M+ members) — see reference-architectures/fhir-server-group-scaling.md. That is a reviewed, in-flight direction for the specific fhir-server use case, not a blanket approval to use ClickHouse as a general operational datastore; a new use case still requires a Tech Design Review."
+
+      - name: "Databricks"
+        type: "analytics-platform"
+        versions: ["Runtime 13.x+"]
+        notes: "Data lakehouse platform for big data analytics and ML pipelines"
+
+  # ============================================================================
+  # Messaging & Events
+  # ============================================================================
+  messaging:
+    severity: "warn"
+    approved:
+      - name: "Kafka"
+        versions: ["3.x"]
+        notes: "Primary async communication; CloudEvents envelope required"
+        patterns:
+          - "CloudEvents format mandatory"
+          - "Idempotent consumers required"
+          - "Partition keys must ensure entity ordering"
+
+      - name: "Kafka Streams"
+        versions: ["3.x"]
+        notes: "Stateful stream processing for Kafka consumers. Use for deduplication, windowing, aggregation, joins. RocksDB state store provides fault-tolerant state via changelog topics. Do NOT use external caches/databases (Caffeine, Redis, MongoDB, PostgreSQL) for Kafka consumer state."
+        patterns:
+          - "State co-located with Kafka partition assignment"
+          - "RocksDB state store backed by changelog topics"
+          - "Tenant isolation in state keys (tenantId prefix)"
+
+  # ============================================================================
+  # Caching
+  # ============================================================================
+  caching:
+    severity: "warn"
+    approved:
+      - name: "Redis"
+        versions: ["7.x"]
+        notes: "Distributed cache standard; tenant keys required; cache introduction requires ADR"
+
+      - name: "In-Process Caching"
+        examples: ["Caffeine (Java)", "node-cache (Node.js)", "cachetools (Python)"]
+        notes: "Service-local caching; requires ADR documenting strategy, size limits, TTL, eviction policy"
+
+  # ============================================================================
+  # Observability
+  # ============================================================================
+  observability:
+    severity: "warn"
+    approved:
+      - name: "OpenTelemetry"
+        versions: ["1.x"]
+        notes: "Tracing, metrics, logs; trace context propagation mandatory"
+        required: true
+
+      - name: "Groundcover"
+        versions: ["Current"]
+        notes: "K8s observability platform"
+
+  # ============================================================================
+  # Infrastructure & DevOps
+  # ============================================================================
+  infrastructure:
+    severity: "warn"
+    approved:
+      - name: "Terraform"
+        versions: ["1.5+"]
+        notes: "IaC standard; all infra changes via Terraform PRs"
+        required: true
+
+      - name: "Docker"
+        versions: ["24+"]
+        notes: "Containerization standard"
+        required: true
+
+      - name: "Kubernetes"
+        versions: ["1.28+"]
+        provider: "AWS EKS"
+        notes: "Orchestration standard"
+
+      - name: "Helm"
+        versions: ["3.x"]
+        notes: "K8s package management; .helm/ structure standard"
+
+      - name: "GitHub Actions"
+        versions: ["Current"]
+        notes: "CI/CD standard"
+
+  # ============================================================================
+  # Testing Frameworks
+  # ============================================================================
+  testing:
+    severity: "warn"
+    approved:
+      - name: "Jest"
+        language: "TypeScript/JavaScript"
+        versions: ["29.x"]
+        notes: "TypeScript/Node.js testing standard"
+
+      - name: "pytest"
+        language: "Python"
+        versions: ["8.x"]
+        notes: "Python testing standard; pytest-cov for coverage"
+
+      - name: "JUnit 5"
+        language: "Java"
+        versions: ["5.10+"]
+        notes: "Java testing standard; Jacoco for coverage"
+
+      - name: "Playwright"
+        category: "e2e"
+        versions: ["1.x"]
+        notes: "Browser testing for web UIs"
+
+      - name: "Detox"
+        category: "mobile-e2e"
+        versions: ["20.x"]
+        notes: "React Native E2E testing"
+
+      - name: "Karate"
+        category: "api"
+        versions: ["1.4+"]
+        notes: "API contract testing"
+
+  # ============================================================================
+  # Linting & Formatting
+  # ============================================================================
+  linting:
+    severity: "warn"
+    approved:
+      - name: "ESLint"
+        language: "TypeScript/JavaScript"
+        versions: ["9.x"]
+        notes: "Flat config (eslint.config.js) preferred; migrate from .eslintrc"
+
+      - name: "Ruff"
+        language: "Python"
+        versions: ["0.3+"]
+        notes: "Python linter; replaces Flake8; combines linting + formatting"
+
+      - name: "Prettier"
+        language: "TypeScript/JavaScript"
+        versions: ["3.x"]
+        notes: "Code formatting; consistent config org-wide"
+
+  # ============================================================================
+  # Security Scanning
+  # ============================================================================
+  security:
+    severity: "warn"
+    approved:
+      - name: "Aikido"
+        category: "SAST/SCA"
+        versions: ["Current"]
+        notes: "SAST and dependency scanning; managed by Security team"
+
+      - name: "CodeQL"
+        category: "SAST"
+        versions: ["Current"]
+        notes: "GitHub native SAST; language-specific queries"
+
+# ============================================================================
+# Migration Notes
+# ============================================================================
+migrations:
+  - from: "Flake8"
+    to: "Ruff"
+    status: "Mandatory"
+    notes: "All repos must migrate to Ruff. Flake8 is deprecated."
+
+  - from: "Black"
+    to: "Ruff Formatter"
+    status: "Mandatory"
+    notes: "Ruff combines linting + formatting; simplifies toolchain. Black is deprecated."
+
+  - from: "Flask"
+    to: "FastAPI"
+    status: "Recommended"
+    notes: "Migrate Flask services to FastAPI for new features; full migration not required immediately"
+
+  - from: ".eslintrc.json"
+    to: "eslint.config.js"
+    status: "Recommended"
+    notes: "ESLint 9+ flat config; improved composability"
+
+# ============================================================================
+# Restricted Technologies
+# ============================================================================
+restricted:
+  - name: "Go"
+    reason: "On hold pending language strategy review. Existing Go services (provider-directory, document-processing-handlers) are grandfathered."
+    exception: "Requires Tech Design Review with EA approval for new services."
+    severity: "error"
+
+  - name: "SQS"
+    reason: "Prefer Kafka for cross-service async communication. SQS creates AWS lock-in and lacks CloudEvents support."
+    exception: "Requires Tech Design Review with EA approval. Must document why Kafka is insufficient."
+    severity: "warn"
+
+  - name: "New Cache Introduction"
+    reason: "All cache introductions (Redis, Caffeine, in-memory) require ADR or Tech Design Review"
+    requiresADR: true
+    exception: "Document cache strategy, size limits, TTL, eviction policy, tenant isolation approach"
+
+  - name: "New NoSQL Databases"
+    reason: "Datastores require Tech Design Review; prefer MongoDB/PostgreSQL"
+    exception: "EA-approved use cases only"
+
+  - name: "Service Meshes"
+    reason: "Complexity vs. benefit trade-off under evaluation"
+    exception: "EA-approved pilots only"
+
+  - name: "Client-Side State Management (Redux, MobX, etc.)"
+    reason: "React Context + hooks preferred for new code"
+    exception: "Legacy codebases maintain existing patterns"
+
+# ============================================================================
+# Review Process
+# ============================================================================
+reviewProcess:
+  trigger: "Introduction of technology not listed in this file"
+  steps:
+    - "Create JIRA ticket in EA project (type: Tech Design Review)"
+    - "Submit Technical Design Document with rationale"
+    - "EA review and approval/rejection"
+    - "If approved, update this file via PR to icanbwell/.github"
+  sla: "5 business days for EA review"
+  appeals: "Escalate to VP Engineering if rejected"


### PR DESCRIPTION
## Architecture Instruction File Sync

This PR updates the organization-wide AI agent instruction baseline files from `icanbwell/.github`.

### Changes
- **AGENTS.md**: Organization-wide baseline (401 lines) codifying b.well architecture standards
- **CLAUDE.md**: Symlink to AGENTS.md for Claude Code compatibility
- **copilot-instructions.md**: Lightweight version for GitHub Copilot
- **policies/approved-tech.yaml**: Technology approval list
- **.github/workflows**: PR architecture review and commit message validation
- **CODEOWNERS**: EA ownership of instruction files

**Source commit**: e161131768903dde30cced1ebf0cc7188509ed58

### Review Notes
Review and merge when ready. These are org-wide architecture instruction updates from EA team. These files are purely additive and don't modify existing code.

Related: EA-2130