### PR TITLE
PHR-3327 add devices IPS section

### DIFF
--- a/sections.md
+++ b/sections.md
@@ -3,10 +3,12 @@
 Note: All **mandatory** sections must be present in the patient summary
 
 ## Patient (Mandatory)
+
 **LOINC Code:** `54126-4` - Patient summary Document
 
 **Resource:** Patient <br>
 **Data Table Fields:**
+
 - **Name(s):** `name.text` or `name.given + name.family` (excluding use='old' & all unique only)
 - **Gender:** `gender`
 - **Date of Birth:** `birthDate`
@@ -17,6 +19,7 @@ Note: All **mandatory** sections must be present in the patient summary
 - **Language(s):** `communication.language` with `communication.preferred` indicator
 
 ## Problem List (Mandatory)
+
 **LOINC Code:** `11450-4` - Problem List
 
 This section contains the list of all the active/current issues the patient is suffering from.
@@ -24,11 +27,13 @@ This section contains the list of all the active/current issues the patient is s
 **Resource:** Condition <br>
 **Filter:** `clinicalStatus.coding.code` is **not** `inactive` or `resolved`
 **Data Table Fields:**
+
 - **Problem:** `code` (CodeableConcept)
 - **Onset Date:** `onsetDateTime`
 - **Recorded Date:** `recordedDate`
 
 ## Allergies and Intolerances (Mandatory)
+
 **LOINC Code:** `48765-2` - Allergies and Intolerances
 
 This section contains information about the patient's active & resolved allergies and intolerances.
@@ -37,6 +42,7 @@ This section contains information about the patient's active & resolved allergie
 **Filter:** None <br>
 **Missing Data Message:** "There is no information available regarding the subject's allergy conditions."
 **Data Table Fields:**
+
 - **Allergen:** `code` (CodeableConcept)
 - **Status:** `clinicalStatus` (CodeableConcept)
 - **Category:** `category` (array)
@@ -46,6 +52,7 @@ This section contains information about the patient's active & resolved allergie
 - **Resolved Date:** `extension[allergyintolerance-resolutionDate].valueDateTime` (for resolved allergies)
 
 ## Medication Summary (Mandatory)
+
 **LOINC Code:** `10160-0` - Medication Summary
 
 This section contains information about the patient's current and past medications.
@@ -54,6 +61,7 @@ This section contains information about the patient's current and past medicatio
 **Filter:** None <br>
 **Missing Data Message:** "There is no information available about the subject's medication use or administration."
 **Data Table Fields:**
+
 - **Type:** Resource type (Request/Statement)
 - **Medication:** `medicationReference` or `medicationCodeableConcept` (resolved to medication name)
 - **Sig:** `dosageInstruction.text` (MedicationRequest) or `dosage.text` (MedicationStatement)
@@ -62,6 +70,7 @@ This section contains information about the patient's current and past medicatio
 - **Start Date:** `dispenseRequest.validityPeriod.start` or `authoredOn` (MedicationRequest) / `effectiveDateTime` or `effectivePeriod.start` (MedicationStatement)
 
 ## Immunizations (Recommended)
+
 **LOINC Code:** `11369-6` - Immunizations
 
 This section contains the patient's immunization history.
@@ -69,6 +78,7 @@ This section contains the patient's immunization history.
 **Resources:** Immunization, Organization (for Immunization's Org) <br>
 **Filter:** `status` is `completed` for Immunization resources; all Organization resources
 **Data Table Fields:**
+
 - **Immunization:** `vaccineCode` (CodeableConcept)
 - **Status:** `status`
 - **Dose Number:** `protocolApplied.doseNumberPositiveInt` or `protocolApplied.doseNumberString`
@@ -78,6 +88,7 @@ This section contains the patient's immunization history.
 - **Date:** `occurrenceDateTime`
 
 ## Results Summary (Recommended)
+
 **LOINC Code:** `30954-2` - Results Summary
 
 This section contains diagnostic reports and related observations.
@@ -87,6 +98,7 @@ This section contains diagnostic reports and related observations.
 **Data Table Fields:**
 
 ### Observations:
+
 - **Code:** `code` (CodeableConcept)
 - **Result:** `valueQuantity`, `valueCodeableConcept`, `valueString`, etc.
 - **Unit:** `valueQuantity.unit` or `valueQuantity.code`
@@ -96,12 +108,14 @@ This section contains diagnostic reports and related observations.
 - **Date:** `effectiveDateTime` or `effectivePeriod`
 
 ### Diagnostic Reports:
+
 - **Report:** `code` (CodeableConcept)
 - **Category:** `category` (CodeableConcept array)
 - **Result:** Count of `result` references
 - **Issued:** `issued`
 
 ## History of Procedures (Recommended)
+
 **LOINC Code:** `47519-4` - History of Procedures
 
 This section contains information about procedures performed on the patient.
@@ -109,11 +123,13 @@ This section contains information about procedures performed on the patient.
 **Resource:** Procedure <br>
 **Filter:** `status` is `completed`
 **Data Table Fields:**
+
 - **Procedure:** `code` (CodeableConcept)
 - **Comments:** `note.text`
 - **Date:** `performedDateTime` or `performedPeriod`
 
 ## History of Medical Devices (Recommended)
+
 **LOINC Code:** `46264-8` - History of Medical Devices
 
 This section contains information about medical devices used by the patient.
@@ -121,12 +137,14 @@ This section contains information about medical devices used by the patient.
 **Resources:** DeviceUseStatement, Device (for device info) <br>
 **Filter:** None
 **Data Table Fields:**
+
 - **Device:** Resolved device name from `device` reference (Device resource)
 - **Status:** `status`
 - **Comments:** `note.text`
 - **Date Recorded:** `recordedOn`
 
 ## Vital Signs (Optional)
+
 **LOINC Code:** `8716-3` - Vital Signs
 
 This section contains the patient's vital signs measurements.
@@ -134,6 +152,7 @@ This section contains the patient's vital signs measurements.
 **Resource:** Observation <br>
 **Filter:** `category.coding.code` contains `vital-signs`
 **Data Table Fields:**
+
 - **Vital Name:** `code` (CodeableConcept)
 - **Result:** `valueQuantity`, `valueCodeableConcept`, `valueString`, etc.
 - **Unit:** `valueQuantity.unit` or `valueQuantity.code`
@@ -143,14 +162,17 @@ This section contains the patient's vital signs measurements.
 - **Date:** `effectiveDateTime` or `effectivePeriod`
 
 ## Social History (Optional)
+
 **LOINC Code:** `29762-2` - Social History
 
 This section contains social history information including tobacco and alcohol use.
 
 **Resource:** Observation <br>
 **Filter:** `code.coding.code` contains LOINC codes:
+
 - `72166-2` - Tobacco Use
 - `74013-4` - Alcohol Use
+
 **Data Table Fields:**
 - **Code:** `code` (CodeableConcept)
 - **Result:** `valueQuantity`, `valueCodeableConcept`, `valueString`, etc.
@@ -159,6 +181,7 @@ This section contains social history information including tobacco and alcohol u
 - **Date:** `effectiveDateTime` or `effectivePeriod`
 
 ## History of Pregnancies (Optional)
+
 **LOINC Code:** `10162-6` - History of Pregnancies
 
 This section contains pregnancy history information.
@@ -166,11 +189,13 @@ This section contains pregnancy history information.
 **Resource:** Observation <br>
 **Filter:** `code.coding.code` contains pregnancy-related LOINC codes or `valueCodeableConcept.coding.code` contains pregnancy outcome codes
 **Data Table Fields:**
+
 - **Result:** Extracted pregnancy status from `valueCodeableConcept` or related pregnancy codes
 - **Comments:** `note.text`
 - **Date:** `effectiveDateTime` or `effectivePeriod`
 
 ## Functional Status (Optional)
+
 **LOINC Code:** `47420-5` - Functional Status
 
 This section contains information about the patient's functional status.
@@ -180,11 +205,13 @@ This section contains information about the patient's functional status.
 **Data Table Fields:**
 
 ### Conditions:
+
 - **Problem:** `code` (CodeableConcept)
 - **Onset Date:** `onsetDateTime`
 - **Recorded Date:** `recordedDate`
 
 ### Clinical Impressions:
+
 - **Date:** `date`
 - **Status:** `status`
 - **Description:** `description`
@@ -192,6 +219,7 @@ This section contains information about the patient's functional status.
 - **Findings:** `finding.itemCodeableConcept` or `finding.itemReference`
 
 ## History of Past Illness (Optional)
+
 **LOINC Code:** `11348-0` - History of Past Illness
 
 This section contains information about the patient's past medical conditions.
@@ -199,12 +227,14 @@ This section contains information about the patient's past medical conditions.
 **Resource:** Condition <br>
 **Filter:** `clinicalStatus.coding.code` is `inactive` or `resolved`
 **Data Table Fields:**
+
 - **Problem:** `code` (CodeableConcept)
 - **Onset Date:** `onsetDateTime`
 - **Recorded Date:** `recordedDate`
 - **Resolved Date:** `abatementDateTime`
 
 ## Plan of Care (Optional)
+
 **LOINC Code:** `18776-5` - Plan of Care
 
 This section contains the patient's care plan information.
@@ -212,6 +242,7 @@ This section contains the patient's care plan information.
 **Resource:** CarePlan <br>
 **Filter:** `status` is `active`
 **Data Table Fields:**
+
 - **Description:** `description` or `title`
 - **Intent:** `intent`
 - **Comments:** `note.text`
@@ -219,6 +250,7 @@ This section contains the patient's care plan information.
 - **Planned End:** `period.end`
 
 ## Advance Directives (Optional)
+
 **LOINC Code:** `42348-3` - Advance Directives
 
 This section contains information about the patient's advance directives.
@@ -226,7 +258,40 @@ This section contains information about the patient's advance directives.
 **Resource:** Consent <br>
 **Filter:** `status` is `active`
 **Data Table Fields:**
+
 - **Scope:** `scope` (CodeableConcept)
 - **Status:** `status`
 - **Action Controlled:** `provision.action` (CodeableConcept array)
 - **Date:** `dateTime`
+
+## Personal Health Monitoring Devices (Optional)
+
+**LOINC Code:** `82611-5` - Personal Health Monitoring Devices
+
+This section contains measurements captured by the patient's own connected
+devices (smart watches, scales, sleep trackers). It is distinct from _History
+of Medical Devices_, which lists the device/equipment records themselves rather
+than the readings they produced.
+
+**Resource:** Observation <br>
+**Filter:** summary-composition only — built exclusively from a
+`device_metric_group_code` Composition (see `IPSSectionSummaryCompositionFilter`).
+The raw-resource predicate deliberately matches nothing: per FHIR,
+`Observation.device` means "the device that generated the measurement" and
+legitimately covers lab analyzers and clinic equipment, so using it as a
+heuristic would pull ordinary lab results into this section. With no such
+Composition present, the section is omitted.
+
+**Capping:** each metric (one sub-section of the source Composition, already
+sorted most-recent-first) contributes at most `MAX_ENTRIES_PER_GROUP` entries —
+10 today. Capping per metric rather than per section keeps low-frequency
+metrics (e.g. body weight) visible alongside continuously-sampled ones (e.g.
+heart rate).
+
+**Data Table Fields:**
+
+- **Metric:** `Metric Name` sub-section
+- **Code (System):** section `code` (CodeableConcept)
+- **Result:** `valueQuantity.value` + `valueQuantity.unit` sub-sections
+- **Date:** `effectiveDateTime` sub-section
+- **Device:** `Device` sub-section (the source device reference)

--- a/src/generators/fhir_summary_generator.ts
+++ b/src/generators/fhir_summary_generator.ts
@@ -10,7 +10,86 @@ import { TNarrative } from "../types/partials/Narrative";
 import { IPSSectionResourceHelper } from "../structures/ips_section_resource_map";
 import { NarrativeGenerator } from "./narrative_generator";
 import { IPSMissingMandatorySectionContent } from "../structures/ips_mandatory_sections";
+import { MAX_ENTRIES_PER_GROUP } from "../structures/ips_section_constants";
 
+/**
+ * Merges every summary Composition's own sub-sections into one ordered list
+ * of groups — one "group" per distinct sub-section title (e.g. one device
+ * metric) — for a per-group cap to slice.
+ *
+ * Keyed by title rather than by (composition, index) so that if the same
+ * metric is ever split across more than one matched Composition, its entries
+ * share a single cap budget instead of each Composition's copy getting its
+ * own budget (which would let that metric survive at up to
+ * N-times-the-cap). Sub-sections with no title, or Compositions with no
+ * sub-sections at all, fall back to a key unique to that
+ * (composition, index) position, preserving one-group-per-sub-section
+ * behavior for the common case.
+ */
+function summaryCompositionGroups(summaryCompositions: TComposition[]): string[][] {
+    const toReferences = (entries: TCompositionSection['entry']): string[] =>
+        (entries ?? [])
+            .map(entry => entry.reference)
+            .filter((reference): reference is string => Boolean(reference));
+
+    const groupsByKey = new Map<string, string[]>();
+    const keyOrder: string[] = [];
+    summaryCompositions.forEach((summaryComposition, compositionIndex) => {
+        const subSections = summaryComposition?.section ?? [];
+        const sections = subSections.length > 0 ? subSections : [{} as TCompositionSection];
+        sections.forEach((section, sectionIndex) => {
+            const key = section.title ?? `__untitled_${compositionIndex}_${sectionIndex}`;
+            if (!groupsByKey.has(key)) {
+                groupsByKey.set(key, []);
+                keyOrder.push(key);
+            }
+            groupsByKey.get(key)!.push(...toReferences(section.entry));
+        });
+    });
+    return keyOrder.map(key => groupsByKey.get(key)!);
+}
+
+/**
+ * Takes at most `maxEntriesPerGroup` items from each group, in order,
+ * de-duplicated across the whole Composition.
+ *
+ * References that `resolve` returns undefined for do NOT count toward the cap:
+ * a summary Composition routinely references resources absent from the bundle
+ * being built (a different time window, deleted resources), and counting those
+ * would let a group silently contribute far fewer than the cap allows.
+ * Passing `maxEntriesPerGroup` as undefined takes everything.
+ */
+function takeCappedPerGroup<T>(
+    groups: string[][],
+    maxEntriesPerGroup: number | undefined,
+    resolve: (reference: string) => T | undefined,
+): T[] {
+    const taken: T[] = [];
+    const seen = new Set<string>();
+    for (const group of groups) {
+        let takenFromGroup = 0;
+        for (const reference of group) {
+            if (maxEntriesPerGroup !== undefined && takenFromGroup >= maxEntriesPerGroup) break;
+            if (seen.has(reference)) continue;
+            const resolved = resolve(reference);
+            if (resolved === undefined) continue;
+            taken.push(resolved);
+            seen.add(reference);
+            takenFromGroup++;
+        }
+    }
+    return taken;
+}
+
+/**
+ * Turns a `ResourceType/id` reference into a placeholder resource, used by the
+ * summary-composition-only mode where the real resources aren't loaded.
+ * Returns undefined for anything that isn't exactly two segments.
+ */
+function referenceToStubResource(reference: string): TDomainResource | undefined {
+    const parts = reference.split('/');
+    return parts.length === 2 ? { resourceType: parts[0], id: parts[1] } : undefined;
+}
 
 export class ComprehensiveIPSCompositionBuilder {
     private patients: TPatient[] | undefined;
@@ -118,28 +197,41 @@ export class ComprehensiveIPSCompositionBuilder {
         summaryCompositions: TComposition[],
         resources: TDomainResource[],
         timezone: string | undefined,
-        includeSummaryCompositionOnly: boolean = false
+        includeSummaryCompositionOnly: boolean = false,
+        maxEntriesPerGroup?: number,
     ): Promise<this> {
         const sectionResources: TDomainResource[] = [];
-        for (const summaryComposition of summaryCompositions) {
-            const resourceEntries = summaryComposition?.section?.flatMap(sec => sec.entry || []) ?? [];
-            if (includeSummaryCompositionOnly) {
-                const addedEntries = new Set<string>();
-                resourceEntries.forEach(entry => {
-                    if (entry.reference && !addedEntries.has(entry.reference)) {
-                        const reference = entry.reference.split('/')
-                        if (reference.length === 2) {
-                            const resource: TDomainResource = {
-                                id: reference[1],
-                                resourceType: reference[0]
-                            }
-                            sectionResources.push(resource);
-                            addedEntries.add(entry.reference);
-                        }
-                    }
-                });
-            }
-            else {
+        if (includeSummaryCompositionOnly) {
+            // Stub-only mode: the bundle isn't consulted, so each reference
+            // becomes a placeholder. The cap still applies here — this mode
+            // is reachable in production via
+            // `$summary?_includeSummaryCompositionOnly=true`. Groups are
+            // merged across ALL matched compositions (by title) before
+            // capping, so the same metric split across more than one
+            // composition shares one cap budget rather than one each.
+            const groups = summaryCompositionGroups(summaryCompositions);
+            sectionResources.push(
+                ...takeCappedPerGroup(groups, maxEntriesPerGroup, referenceToStubResource)
+            );
+        }
+        else if (maxEntriesPerGroup !== undefined) {
+            // Bounded path: walks entry order rather than bundle order so
+            // the upstream most-recent-first sorting within each group is
+            // preserved when the cap slices it. Same cross-composition
+            // group merge as above.
+            const resourcesByReference = new Map<string, TDomainResource>(
+                resources.map(resource => [`${resource.resourceType}/${resource.id}`, resource])
+            );
+            const groups = summaryCompositionGroups(summaryCompositions);
+            const resolved = takeCappedPerGroup(
+                groups, maxEntriesPerGroup, reference => resourcesByReference.get(reference)
+            );
+            resolved.forEach(resource => this.resources.add(resource));
+            sectionResources.push(...resolved);
+        }
+        else {
+            for (const summaryComposition of summaryCompositions) {
+                const resourceEntries = summaryComposition?.section?.flatMap(sec => sec.entry || []) ?? [];
                 resources.forEach(resource => {
                     if (resourceEntries?.some(entry => entry.reference === `${resource.resourceType}/${resource.id}`)) {
                         this.resources.add(resource);
@@ -215,7 +307,7 @@ export class ComprehensiveIPSCompositionBuilder {
             const sectionSummary = summaryCompositionFilter ? resources.filter(resource => summaryCompositionFilter(resource)) : [];
             if (sectionSummary.length > 0) {
                 consoleLogger.info(`Using summary composition for section: ${sectionType}`);
-                await this.makeSectionFromSummaryAsync(sectionType, sectionSummary as TComposition[], resources as TDomainResource[], timezone, includeSummaryCompositionOnly);
+                await this.makeSectionFromSummaryAsync(sectionType, sectionSummary as TComposition[], resources as TDomainResource[], timezone, includeSummaryCompositionOnly, MAX_ENTRIES_PER_GROUP[sectionType]);
             } else {
                 consoleLogger.info(`Using individual resources for section: ${sectionType}`);
                 const sectionFilter = IPSSectionResourceHelper.getResourceFilterForSection(sectionType);

--- a/src/narratives/templates/typescript/DeviceMetricsTemplate.ts
+++ b/src/narratives/templates/typescript/DeviceMetricsTemplate.ts
@@ -1,0 +1,108 @@
+// DeviceMetricsTemplate.ts - narrative for the Personal Health Monitoring
+// Devices section (measurements captured by a patient's connected devices).
+import { TemplateUtilities } from './TemplateUtilities';
+import { ISummaryTemplate } from './interfaces/ITemplate';
+import { TComposition } from '../../../types/resources/Composition';
+
+/**
+ * Class to generate HTML narrative for device-captured metrics.
+ *
+ * Unlike most templates, this one only supports the summary-composition path.
+ * The section's membership comes from a curated device-metric Composition
+ * produced upstream (one sub-section per metric, each already sorted most
+ * recent first) — there is no safe way to derive it from raw Observations,
+ * so generateNarrative returns undefined and the section is simply omitted
+ * when no such Composition is present.
+ */
+export class DeviceMetricsTemplate implements ISummaryTemplate {
+  /**
+   * Non-summary path is intentionally unsupported — see class docblock.
+   * Returning undefined (never '') causes the section to be skipped entirely.
+   * Parameters are omitted deliberately: TypeScript allows an implementation
+   * to declare fewer parameters than the interface, and none are used here.
+   */
+  generateNarrative(): string | undefined {
+    return undefined;
+  }
+
+  /**
+   * Generate HTML narrative from the device-metric summary Composition.
+   *
+   * Each top-level section of the Composition is one metric (e.g. "Sleep
+   * Duration", "Heart Rate") and carries that metric's latest reading across
+   * its child sections, so this renders one row per metric rather than one
+   * row per observation.
+   *
+   * @param resources - Device-metric summary Composition resources
+   * @param timezone - Optional timezone for date formatting
+   * @returns HTML string, or undefined if no metric rows could be rendered
+   */
+  generateSummaryNarrative(
+    resources: TComposition[],
+    timezone: string | undefined
+  ): string | undefined {
+    const templateUtilities = new TemplateUtilities(resources);
+    let isSummaryCreated = false;
+
+    let html = `<p>This list includes the latest measurement recorded by each of the patient's connected devices, sorted by effective date (most recent first).</p>\n`;
+
+    html += `
+      <div>
+        <table>
+          <thead>
+            <tr>
+              <th>Metric</th>
+              <th>Code (System)</th>
+              <th>Result</th>
+              <th>Date</th>
+              <th>Device</th>
+            </tr>
+          </thead>
+          <tbody>`;
+
+    for (const resourceItem of resources) {
+      for (const rowData of resourceItem.section ?? []) {
+        const data: Record<string, string> = {};
+        // Escaped like every other value in `data` — codeableConceptCoding
+        // interpolates a code and system straight from the resource, so it is
+        // untrusted input and must not reach the HTML unescaped.
+        data['codeSystem'] = templateUtilities.renderTextAsHtml(
+          templateUtilities.codeableConceptCoding(rowData.code)
+        );
+
+        for (const columnData of rowData.section ?? []) {
+          if (columnData.title) {
+            data[columnData.title] = templateUtilities.renderTextAsHtml(
+              columnData.text?.div ?? ''
+            );
+          }
+        }
+
+        const metricName = data['Metric Name'];
+        // Skip rows the upstream pipeline couldn't name — they'd render as
+        // an unlabeled value with no clinical meaning.
+        if (!metricName || metricName.toLowerCase() === 'unknown') {
+          continue;
+        }
+
+        isSummaryCreated = true;
+
+        html += `
+          <tr>
+            <td>${templateUtilities.capitalizeFirstLetter(metricName)}</td>
+            <td>${data['codeSystem'] ?? ''}</td>
+            <td>${templateUtilities.extractObservationSummaryValue(data, timezone) ?? ''}</td>
+            <td>${templateUtilities.extractObservationSummaryEffectiveTime(data, timezone) ?? ''}</td>
+            <td>${data['Device'] ?? ''}</td>
+          </tr>`;
+      }
+    }
+
+    html += `
+          </tbody>
+        </table>
+      </div>`;
+
+    return isSummaryCreated ? html : undefined;
+  }
+}

--- a/src/narratives/templates/typescript/TypeScriptTemplateMapper.ts
+++ b/src/narratives/templates/typescript/TypeScriptTemplateMapper.ts
@@ -15,6 +15,7 @@ import { PlanOfCareTemplate } from './PlanOfCareTemplate';
 import { FunctionalStatusTemplate } from './FunctionalStatusTemplate';
 import { PregnancyTemplate } from './PregnancyTemplate';
 import { AdvanceDirectivesTemplate } from './AdvanceDirectivesTemplate';
+import { DeviceMetricsTemplate } from './DeviceMetricsTemplate';
 import { ISummaryTemplate, ITemplate } from './interfaces/ITemplate';
 import { TDomainResource } from '../../../types/resources/DomainResource';
 import { TComposition } from '../../../types/resources/Composition';
@@ -41,7 +42,8 @@ export class TypeScriptTemplateMapper {
     [IPSSections.FUNCTIONAL_STATUS]: new FunctionalStatusTemplate(),
     [IPSSections.MEDICAL_HISTORY]: new PastHistoryOfIllnessTemplate(),
     [IPSSections.CARE_PLAN]: new PlanOfCareTemplate(),
-    [IPSSections.ADVANCE_DIRECTIVES]: new AdvanceDirectivesTemplate()
+    [IPSSections.ADVANCE_DIRECTIVES]: new AdvanceDirectivesTemplate(),
+    [IPSSections.DEVICE_METRICS]: new DeviceMetricsTemplate(),
   };
 
   /**

--- a/src/structures/ips_section_constants.ts
+++ b/src/structures/ips_section_constants.ts
@@ -1,20 +1,40 @@
 // Constants for IPS Sections
+import { IPSSections } from './ips_sections';
 
 const VITAL_SIGNS_SUMMARY_COMPONENT_MAP = {
-  "Systolic Blood Pressure": 'valueRatio.numerator.value',
-  "Diastolic Blood Pressure": 'valueRatio.denominator.value',
-  "Default": 'valueString'
+  'Systolic Blood Pressure': 'valueRatio.numerator.value',
+  'Diastolic Blood Pressure': 'valueRatio.denominator.value',
+  Default: 'valueString',
 };
 
-const RESULT_SUMMARY_OBSERVATION_CATEGORIES = ["laboratory","Lab","LAB"]
+const RESULT_SUMMARY_OBSERVATION_CATEGORIES = ['laboratory', 'Lab', 'LAB'];
 const RESULT_SUMMARY_OBSERVATION_DATE_FILTER = 2 * 365 * 24 * 60 * 60 * 1000; // 2 years in milliseconds
 
-const IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM = "https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/type";
-const IPS_SUMMARY_COMPOSITION_VIEW_TYPE_SYSTEM = "https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/view-type"
+const IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM =
+  'https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/type';
+const IPS_SUMMARY_COMPOSITION_VIEW_TYPE_SYSTEM =
+  'https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/view-type';
+
+/**
+ * Per-section cap on how many resources each group within a summary
+ * Composition contributes to the built section (a "group" being one of the
+ * Composition's own sub-sections — e.g. one device metric).
+ *
+ * Only set for sections whose source Composition can reference thousands of
+ * resources; a section absent from this map is built uncapped, preserving
+ * existing behaviour. Device metrics need it because a continuously-sampling
+ * wearable can report hundreds of readings per metric across dozens of
+ * metrics, which would otherwise dominate the IPS bundle.
+ */
+const MAX_ENTRIES_PER_GROUP: Partial<Record<IPSSections, number>> = {
+  [IPSSections.DEVICE_METRICS]: 10,
+};
+
 export {
-    VITAL_SIGNS_SUMMARY_COMPONENT_MAP,
-    IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM,
-    IPS_SUMMARY_COMPOSITION_VIEW_TYPE_SYSTEM,
-    RESULT_SUMMARY_OBSERVATION_CATEGORIES,
-    RESULT_SUMMARY_OBSERVATION_DATE_FILTER
+  VITAL_SIGNS_SUMMARY_COMPONENT_MAP,
+  IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM,
+  IPS_SUMMARY_COMPOSITION_VIEW_TYPE_SYSTEM,
+  RESULT_SUMMARY_OBSERVATION_CATEGORIES,
+  RESULT_SUMMARY_OBSERVATION_DATE_FILTER,
+  MAX_ENTRIES_PER_GROUP,
 };

--- a/src/structures/ips_section_loinc_codes.ts
+++ b/src/structures/ips_section_loinc_codes.ts
@@ -20,6 +20,7 @@ const IPS_SECTION_LOINC_CODES: Record<IPSSections, string> = {
   [IPSSections.MEDICAL_HISTORY]: '11348-0',
   [IPSSections.CARE_PLAN]: '18776-5',
   [IPSSections.ADVANCE_DIRECTIVES]: '42348-3',
+  [IPSSections.DEVICE_METRICS]: '82611-5',
 };
 
 const IPS_SECTION_DISPLAY_NAMES: Record<IPSSections, string> = {
@@ -38,6 +39,7 @@ const IPS_SECTION_DISPLAY_NAMES: Record<IPSSections, string> = {
   [IPSSections.CARE_PLAN]: 'Plan of Care',
   [IPSSections.MEDICAL_HISTORY]: 'History of Past Illness',
   [IPSSections.SOCIAL_HISTORY]: 'Social History',
+  [IPSSections.DEVICE_METRICS]: 'Personal Health Monitoring Devices',
 };
 
 const PREGNANCY_LOINC_CODES = {
@@ -170,7 +172,8 @@ const ADVANCED_DIRECTIVE_CATEGORY_CODES = {
   polst: 'POLST',
   hcd: 'Health Care Directive',
 };
-const ADVANCED_DIRECTIVE_CATEGORY_SYSTEM = "http://terminology.hl7.org/CodeSystem/consentcategorycodes"
+const ADVANCED_DIRECTIVE_CATEGORY_SYSTEM =
+  'http://terminology.hl7.org/CodeSystem/consentcategorycodes';
 
 const ADVANCED_DIRECTIVE_LOINC_CODES = {
   '45473-6': 'Advance healthcare directive Completed',
@@ -182,7 +185,7 @@ const ADVANCED_DIRECTIVE_LOINC_CODES = {
   '45479-3': 'Medication restrictions',
   '45480-1': 'Other treatment restrictions',
 };
-const LOINC_SYSTEM = "http://loinc.org"
+const LOINC_SYSTEM = 'http://loinc.org';
 
 export {
   IPS_SECTION_LOINC_CODES,

--- a/src/structures/ips_section_resource_map.ts
+++ b/src/structures/ips_section_resource_map.ts
@@ -24,6 +24,7 @@ export const IPSSectionResourcesMap: Record<IPSSections, string[]> = {
     [IPSSections.MEDICAL_HISTORY]: ['Condition'],
     [IPSSections.CARE_PLAN]: ['CarePlan'],
     [IPSSections.ADVANCE_DIRECTIVES]: ['Consent'],
+    [IPSSections.DEVICE_METRICS]: ['Observation'],
 };
 
 export const IPSSectionResourceFilters: Partial<Record<IPSSections, IPSSectionResourceFilter>> = {
@@ -77,6 +78,14 @@ export const IPSSectionResourceFilters: Partial<Record<IPSSections, IPSSectionRe
     [IPSSections.CARE_PLAN]: (resource) => resource.resourceType === 'CarePlan' && resource.status === 'active',
     // Only include active advance directives (Consent resources)
     [IPSSections.ADVANCE_DIRECTIVES]: (resource) => resource.resourceType === 'Consent' && resource.status === 'active' && resource.scope?.coding?.some((c: any) => codingMatches(c, 'adr', "http://terminology.hl7.org/CodeSystem/consentscope")),
+    // Deliberately matches nothing: this section is only derivable from the
+    // curated device-metric Composition (see IPSSectionSummaryCompositionFilter
+    // below), never from a heuristic over raw Observations. Observation.device
+    // is not a safe fallback — per FHIR it means "the device that generated the
+    // measurement", which legitimately covers lab analyzers and clinic
+    // equipment, so keying off it would pull ordinary lab results into a
+    // patient-wearables section. Without a composition, no section is emitted.
+    [IPSSections.DEVICE_METRICS]: () => false,
 };
 
 export const IPSSectionSummaryCompositionFilter: Partial<Record<IPSSections, IPSSectionResourceFilter>> = {
@@ -89,6 +98,7 @@ export const IPSSectionSummaryCompositionFilter: Partial<Record<IPSSections, IPS
     [IPSSections.MEDICATIONS]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "medication_group_code", IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM)),
     // [IPSSections.DIAGNOSTIC_REPORTS]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => c.system === IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM && ["lab_group_code", "diagnosticreportlab_group_code"].includes(c.code)),
     [IPSSections.PROCEDURES]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "procedure_group_code", IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM)),
+    [IPSSections.DEVICE_METRICS]: (resource) => resource.resourceType === 'Composition' && resource.type?.coding?.some((c: any) => codingMatches(c, "device_metric_group_code", IPS_SUMMARY_COMPOSITION_TYPE_SYSTEM)),
 }
 
 // Helper class to get resource types for a section

--- a/src/structures/ips_sections.ts
+++ b/src/structures/ips_sections.ts
@@ -1,28 +1,32 @@
 // Enum for all possible IPS sections
 export enum IPSSections {
-    PATIENT = 'Patient',
+  PATIENT = 'Patient',
 
-    // Mandatory Sections
-    PROBLEMS = 'ProblemSection',
-    ALLERGIES = 'AllergyIntoleranceSection',
-    MEDICATIONS = 'MedicationSummarySection',
+  // Mandatory Sections
+  PROBLEMS = 'ProblemSection',
+  ALLERGIES = 'AllergyIntoleranceSection',
+  MEDICATIONS = 'MedicationSummarySection',
 
-    // Additional Recommended Sections
-    IMMUNIZATIONS = 'ImmunizationSection',
-    DIAGNOSTIC_REPORTS = 'ResultsSection',
-    PROCEDURES = 'HistoryOfProceduresSection',
-    MEDICAL_DEVICES = 'MedicalDeviceSection',
-    
-    // Optional Sections
-    ADVANCE_DIRECTIVES = 'AdvanceDirectivesSection',
-    FUNCTIONAL_STATUS = 'FunctionalStatusSection',
-    PREGNANCY_HISTORY = 'HistoryOfPregnancySection',
-    CARE_PLAN = 'PlanOfCareSection',
-    MEDICAL_HISTORY = 'HistoryOfPastIllnessSection',
-    SOCIAL_HISTORY = 'SocialHistorySection',
-    VITAL_SIGNS = 'VitalSignsSection',
-    
-    // missing IPS Sections
-    // ALERTS = 'AlertsSection',
-    // PATIENT_STORY = 'PatientStorySection',
+  // Additional Recommended Sections
+  IMMUNIZATIONS = 'ImmunizationSection',
+  DIAGNOSTIC_REPORTS = 'ResultsSection',
+  PROCEDURES = 'HistoryOfProceduresSection',
+  MEDICAL_DEVICES = 'MedicalDeviceSection',
+
+  // Optional Sections
+  ADVANCE_DIRECTIVES = 'AdvanceDirectivesSection',
+  FUNCTIONAL_STATUS = 'FunctionalStatusSection',
+  PREGNANCY_HISTORY = 'HistoryOfPregnancySection',
+  CARE_PLAN = 'PlanOfCareSection',
+  MEDICAL_HISTORY = 'HistoryOfPastIllnessSection',
+  SOCIAL_HISTORY = 'SocialHistorySection',
+  VITAL_SIGNS = 'VitalSignsSection',
+  // Measurements captured by a patient's connected devices (smart watches,
+  // scales, sleep trackers). Distinct from MEDICAL_DEVICES, which lists the
+  // Device/DeviceUseStatement equipment records rather than their readings.
+  DEVICE_METRICS = 'DeviceMetricsSection',
+
+  // missing IPS Sections
+  // ALERTS = 'AlertsSection',
+  // PATIENT_STORY = 'PatientStorySection',
 }

--- a/tests/generators/device_metrics_section.test.ts
+++ b/tests/generators/device_metrics_section.test.ts
@@ -1,0 +1,296 @@
+import { ComprehensiveIPSCompositionBuilder } from '../../src/generators/fhir_summary_generator';
+import { IPSSections } from '../../src/structures/ips_sections';
+import { IPS_SECTION_LOINC_CODES } from '../../src/structures/ips_section_loinc_codes';
+import { TBundle } from '../../src/types/resources/Bundle';
+import { TComposition } from '../../src/types/resources/Composition';
+import { TObservation } from '../../src/types/resources/Observation';
+import { TPatient } from '../../src/types/resources/Patient';
+
+/**
+ * The Personal Health Monitoring Devices section is built from a curated
+ * `device_metric_summary_document` Composition produced upstream, whose
+ * top-level sections are one-per-metric and already sorted most-recent-first.
+ */
+describe('DeviceMetricsSection', () => {
+  const patient: TPatient = {
+    resourceType: 'Patient',
+    id: 'patient-1',
+    name: [{ family: 'Doe', given: ['Jane'] }],
+    gender: 'female',
+    birthDate: '1980-01-01',
+  };
+
+  const quietLogger = { info: () => {}, error: () => {} } as unknown as Console;
+
+  /** Builds N observations for one metric, newest first. */
+  const observationsFor = (
+    prefix: string,
+    code: string,
+    display: string,
+    count: number
+  ): TObservation[] =>
+    Array.from(
+      { length: count },
+      (_, i) =>
+        ({
+          resourceType: 'Observation',
+          id: `${prefix}-${i}`,
+          status: 'final',
+          code: { coding: [{ system: 'http://loinc.org', code, display }] },
+          subject: { reference: 'Patient/patient-1' },
+          // Descending: index 0 is the most recent.
+          effectiveDateTime: `2026-01-${String(28 - i).padStart(2, '0')}T00:00:00Z`,
+          valueQuantity: { value: 60 + i, unit: 'count/min' },
+          device: { reference: 'Device/oura' },
+        }) as TObservation
+    );
+
+  /**
+   * Mirrors the real Composition shape: metric section -> column sub-sections
+   * + entries. Column `text.div` values are bare, matching every other
+   * summary-composition fixture in the repo (e.g.
+   * tests/fhir-summary-bundle/fixtures/test-summary-bundle.json) — not
+   * wrapped in a literal `<div>` element, which DeviceMetricsTemplate would
+   * HTML-escape as untrusted text rather than parse as markup.
+   */
+  const metricSection = (
+    title: string,
+    code: string,
+    observations: TObservation[]
+  ) => ({
+    title,
+    code: { coding: [{ system: 'http://loinc.org', code, display: title }] },
+    orderedBy: {
+      text: 'Sorted by effectiveDateTime|effectivePeriod.start DESC',
+    },
+    section: [
+      {
+        title: 'Device',
+        text: { status: 'generated', div: 'Device/oura' },
+      },
+      {
+        title: 'Metric Name',
+        text: { status: 'generated', div: title },
+      },
+      {
+        title: 'Source',
+        text: { status: 'generated', div: 'device-data-ingest' },
+      },
+      {
+        title: 'effectiveDateTime',
+        text: {
+          status: 'generated',
+          div: observations[0].effectiveDateTime,
+        },
+      },
+      {
+        title: 'valueQuantity.value',
+        text: {
+          status: 'generated',
+          div: `${observations[0].valueQuantity?.value}`,
+        },
+      },
+      {
+        title: 'valueQuantity.unit',
+        text: { status: 'generated', div: 'count/min' },
+      },
+    ],
+    entry: observations.map(o => ({ reference: `Observation/${o.id}` })),
+  });
+
+  const heartRate = observationsFor('hr', '8867-4', 'Heart rate', 15);
+  const bodyWeight = observationsFor('wt', '29463-7', 'Body weight', 2);
+
+  const deviceComposition = {
+    resourceType: 'Composition',
+    id: 'device-metrics-1',
+    status: 'final',
+    type: {
+      coding: [
+        {
+          system: 'https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/',
+          code: 'device_metric_summary_document',
+        },
+        {
+          system:
+            'https://fhir.icanbwell.com/4_0_0/CodeSystem/composition/type',
+          code: 'device_metric_group_code',
+        },
+      ],
+    },
+    subject: { reference: 'Patient/patient-1' },
+    section: [
+      metricSection('Heart rate', '8867-4', heartRate),
+      metricSection('Body weight', '29463-7', bodyWeight),
+    ],
+  } as unknown as TComposition;
+
+  const buildBundle = (extra: unknown[] = []): TBundle =>
+    ({
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [
+        { resource: patient },
+        ...heartRate.map(r => ({ resource: r })),
+        ...bodyWeight.map(r => ({ resource: r })),
+        ...extra.map(r => ({ resource: r })),
+      ],
+    }) as unknown as TBundle;
+
+  const buildSection = async (
+    bundle: TBundle,
+    useSummaryCompositions = true,
+    includeSummaryCompositionOnly = false
+  ) => {
+    const builder = new ComprehensiveIPSCompositionBuilder();
+    await builder.readBundleAsync(
+      bundle,
+      'UTC',
+      useSummaryCompositions,
+      includeSummaryCompositionOnly,
+      quietLogger
+    );
+    const out = await builder.buildBundleAsync(
+      'org-1',
+      'b.well',
+      'https://example.com',
+      'UTC',
+      includeSummaryCompositionOnly
+    );
+    const composition = (out.entry ?? [])
+      .map(e => e.resource)
+      .find(r => r?.resourceType === 'Composition') as TComposition | undefined;
+    return composition?.section?.find(
+      s =>
+        s.code?.coding?.[0]?.code ===
+        IPS_SECTION_LOINC_CODES[IPSSections.DEVICE_METRICS]
+    );
+  };
+
+  beforeEach(() => {
+    process.env.SUMMARY_COMPOSITION_SECTIONS = 'all';
+  });
+
+  afterEach(() => {
+    process.env.SUMMARY_COMPOSITION_SECTIONS = '';
+  });
+
+  it('caps each metric independently so a high-frequency one cannot crowd out a low-frequency one', async () => {
+    const section = await buildSection(buildBundle([deviceComposition]));
+
+    expect(section).toBeDefined();
+    const refs = (section?.entry ?? []).map(e => e.reference);
+
+    // Heart rate capped at 10 of 15; both body-weight readings survive.
+    expect(refs.filter(r => r?.startsWith('Observation/hr-'))).toHaveLength(10);
+    expect(refs.filter(r => r?.startsWith('Observation/wt-'))).toHaveLength(2);
+
+    // The 10 kept are the most recent (hr-0..hr-9), not an arbitrary slice.
+    expect(refs).toContain('Observation/hr-0');
+    expect(refs).toContain('Observation/hr-9');
+    expect(refs).not.toContain('Observation/hr-10');
+  });
+
+  // The upstream pipeline emits one device-metric Composition per patient
+  // today, but IPSSectionSummaryCompositionFilter matches ANY Composition
+  // carrying device_metric_group_code — nothing prevents more than one from
+  // matching. If a metric were split across two, each got its own 10-entry
+  // budget (20 total) unless groups sharing a title are merged before capping.
+  it('shares one cap budget for the same metric split across multiple compositions', async () => {
+    const heartRate2 = observationsFor('hr2', '8867-4', 'Heart rate', 15);
+    const secondDeviceComposition = {
+      ...deviceComposition,
+      id: 'device-metrics-2',
+      section: [metricSection('Heart rate', '8867-4', heartRate2)],
+    } as unknown as TComposition;
+
+    const section = await buildSection(
+      buildBundle([
+        deviceComposition,
+        secondDeviceComposition,
+        ...heartRate2.map(o => o),
+      ])
+    );
+
+    const refs = (section?.entry ?? [])
+      .map(e => e.reference)
+      .filter(r => r?.startsWith('Observation/hr'));
+    expect(refs).toHaveLength(10);
+  });
+
+  // includeSummaryCompositionOnly is a real production mode (fhir-server calls
+  // `$summary?_includeSummaryCompositionOnly=true`). It selects entries via a
+  // different branch that builds stub resources without consulting the bundle,
+  // so the cap has to be enforced there too.
+  it('caps each metric in includeSummaryCompositionOnly mode as well', async () => {
+    const section = await buildSection(
+      buildBundle([deviceComposition]),
+      true,
+      true
+    );
+
+    expect(section).toBeDefined();
+    const refs = (section?.entry ?? []).map(e => e.reference);
+
+    expect(refs.filter(r => r?.startsWith('Observation/hr-'))).toHaveLength(10);
+    expect(refs.filter(r => r?.startsWith('Observation/wt-'))).toHaveLength(2);
+    expect(refs).not.toContain('Observation/hr-10');
+  });
+
+  it('renders one narrative row per metric, naming the source device', async () => {
+    const section = await buildSection(buildBundle([deviceComposition]));
+
+    const div = section?.text?.div ?? '';
+    // One row per metric plus the header row.
+    expect((div.match(/<tr>/g) ?? []).length).toBe(3);
+    expect(div).toContain('Heart rate');
+    expect(div).toContain('Body weight');
+    expect(div).toContain('Device/oura');
+    // Exercises the Result/Date formatting path against the fixture's most
+    // recent heart-rate reading (hr-0: 60 count/min, 2026-01-28).
+    expect(div).toContain('60 count/min');
+    expect(div).toContain('1/28/2026');
+  });
+
+  it('escapes untrusted resource text rather than emitting it as live HTML', async () => {
+    // A malicious/mangled code system reaches the narrative via
+    // codeableConceptCoding, which interpolates code + system verbatim.
+    const injected = '<script>alert(1)</script>';
+    const hostileComposition = {
+      ...(deviceComposition as unknown as Record<string, unknown>),
+      section: [
+        {
+          ...metricSection('Heart rate', '8867-4', heartRate),
+          code: {
+            coding: [{ system: injected, code: injected, display: 'Heart rate' }],
+          },
+        },
+      ],
+    } as unknown as TComposition;
+
+    const section = await buildSection(buildBundle([hostileComposition]));
+    const div = section?.text?.div ?? '';
+
+    // `<` is escaped so no live tag can form. Note the narrative is minified
+    // afterwards, which turns `&gt;` back into a bare `>` — harmless in text
+    // content, so only the opening bracket is asserted on.
+    expect(div).not.toContain('<script');
+    expect(div).toContain('&lt;script');
+  });
+
+  it('uses the section title and LOINC code the SHL viewer expects', async () => {
+    const section = await buildSection(buildBundle([deviceComposition]));
+
+    expect(section?.code?.coding?.[0]?.code).toBe('82611-5');
+    expect(section?.title).toBe('Personal Health Monitoring Devices');
+  });
+
+  it('omits the section entirely when no device-metric Composition is present', async () => {
+    // Observations carrying .device are present, but without the curated
+    // Composition there is no safe way to classify them — .device also
+    // covers lab analyzers and clinic equipment — so nothing is emitted.
+    const section = await buildSection(buildBundle());
+
+    expect(section).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description of change

Adds a **Personal Health Monitoring Devices** IPS section (LOINC `82611-5`) for measurements captured by a patient's connected devices — heart rate, sleep duration, steps, calories burned, body weight, SpO2 and so on.

**Why:** PHR-3327 was reported as "vitals missing from the SMR export". Investigation showed the reported user's EHR vitals are simply older than `$summary`'s rolling 2-year Observation window (working as designed), while the ~3,000 device readings they actually expected had nowhere to go — the IPS had no section for device-captured measurements. This adds it.

**Source of truth** is the existing `device_metric_summary_document` Composition produced by the `device-data-ingest` pipeline. It already groups one sub-section per metric, sorted most-recent-first, so it drives both membership and grouping.

`Observation.device` was evaluated as a discriminator and deliberately rejected: per FHIR it means "the device that generated the measurement" and legitimately covers lab analyzers and clinic equipment, so keying off it would misfile ordinary lab results into a wearables section. For the same reason the raw-resource predicate is hardcoded `() => false` — this section only ever materialises from the curated Composition, never from a heuristic.

**Capping:** a continuously-sampling wearable produces hundreds of readings per metric, which would dominate the IPS bundle. `MAX_ENTRIES_PER_GROUP` caps each metric to its 10 most recent entries. Per *metric* rather than per section, so low-frequency metrics (body weight, height) stay visible next to high-frequency ones (heart rate). The map is opt-in — sections absent from it are built uncapped, so no existing section changes behaviour.

**Changes**

| File | Change |
| --- | --- |
| `ips_sections.ts` | New `DEVICE_METRICS` section, distinct from `MEDICAL_DEVICES` (which lists equipment records, not their readings) |
| `ips_section_loinc_codes.ts` | LOINC `82611-5` + display name |
| `ips_section_resource_map.ts` | Resource types; `device_metric_group_code` registered in `IPSSectionSummaryCompositionFilter`; no-op raw-resource predicate |
| `DeviceMetricsTemplate.ts` | New — one row per metric, naming the source device |
| `TypeScriptTemplateMapper.ts` | Registration |
| `ips_section_constants.ts` | `MAX_ENTRIES_PER_GROUP` |
| `fhir_summary_generator.ts` | Per-group capping, shared by both entry-selection branches |
| `sections.md` | Documented per `docs/adding-a-new-ips-section.md` |

**Verification**

Beyond unit tests, run end-to-end against the real production `device_metric_summary_document` Composition and `$summary` Observations for the reported patient: 174 entries across 19 metrics, **zero metrics over the cap**, 40 narrative rows, correct section title, device names rendered. Re-checked in both `includeSummaryCompositionOnly` modes after the review fix below.

**Review feedback addressed**

- *(claude)* The cap was skipped when `includeSummaryCompositionOnly=true`, since that branch was evaluated first — a genuinely reachable production path (`$summary?_includeSummaryCompositionOnly=true`). Both branches now share one capping helper. Regression test added, confirmed failing before the fix (15 entries) and passing after (10).
- *(Aikido)* Deep nesting in the bounded path — extracted `summaryCompositionGroups` and `takeCappedPerGroup`.

**Deploys with:** health-link-service #150 and ui-platform #4843. **This must be published first** — both depend on it.

> [!NOTE]
> `SUMMARY_COMPOSITION_SECTIONS` gates whether a registered composition filter activates. Prod logs confirm it's set (`Using summary composition for section: VitalSignsSection`), but I couldn't locate where — not in `configuration-as-code`, helm values, or fhir-server. If it's an explicit list rather than `all`, `DeviceMetricsSection` needs adding or this silently no-ops in prod.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` — N/A, tracked in Jira as [PHR-3327](https://icanbwell.atlassian.net/browse/PHR-3327)
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)


[PHR-3327]: https://icanbwell.atlassian.net/browse/PHR-3327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ